### PR TITLE
Add missing cstdint includes to LLVM

### DIFF
--- a/llvm/include/llvm/ADT/SmallVector.h
+++ b/llvm/include/llvm/ADT/SmallVector.h
@@ -19,6 +19,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cstddef>
+#include <cstdint>
 #include <cstdlib>
 #include <cstring>
 #include <functional>

--- a/llvm/lib/Target/X86/MCTargetDesc/X86MCTargetDesc.h
+++ b/llvm/lib/Target/X86/MCTargetDesc/X86MCTargetDesc.h
@@ -15,6 +15,7 @@
 
 #include <memory>
 #include <string>
+#include <cstdint>
 
 namespace llvm {
 class formatted_raw_ostream;


### PR DESCRIPTION
This allows me to build LLVM on up-to-date Arch Linux. One of these is cherry-picked from a newer version of LLVM, the other I couldn't find a commit to cherry-pick so I added it myself.