### PR TITLE
Remove passwd->pw_gecos check from miscsyscall test

### DIFF
--- a/filc/tests/miscsyscall/miscsyscall.c
+++ b/filc/tests/miscsyscall/miscsyscall.c
@@ -111,7 +111,6 @@ int main(int argc, char** argv)
     ZASSERT(strlen(passwd->pw_passwd));
     ZASSERT(passwd->pw_uid == getuid());
     ZASSERT(passwd->pw_gid == getgid());
-    ZASSERT(strlen(passwd->pw_gecos));
     ZASSERT(strlen(passwd->pw_dir));
     ZASSERT(strlen(passwd->pw_shell));
 


### PR DESCRIPTION
It looks like `pw_gecos` is only non-empty when the user has a full name set. My code user doesn't have one, so this test was failing. This one check doesn't seem particularly important, especially since its still validating lots of other fields of the struct.