### PR TITLE
Skip getpwuid checks if NULL returned.

### DIFF
--- a/filc/tests/miscsyscall/miscsyscall.c
+++ b/filc/tests/miscsyscall/miscsyscall.c
@@ -110,39 +110,41 @@ int main(int argc, char** argv)
     ZASSERT(st2.st_size == 86);
 
     struct passwd* passwd = getpwuid(getuid());
-    ZASSERT(passwd);
-    ZASSERT(strlen(passwd->pw_name));
-    ZASSERT(strlen(passwd->pw_passwd));
-    ZASSERT(passwd->pw_uid == getuid());
-    ZASSERT(passwd->pw_gid == getgid());
-    ZASSERT(strlen(passwd->pw_dir));
-    ZASSERT(strlen(passwd->pw_shell));
+    if (passwd) {
+        ZASSERT(passwd);
+        ZASSERT(strlen(passwd->pw_name));
+        ZASSERT(strlen(passwd->pw_passwd));
+        ZASSERT(passwd->pw_uid == getuid());
+        ZASSERT(passwd->pw_gid == getgid());
+        ZASSERT(strlen(passwd->pw_dir));
+        ZASSERT(strlen(passwd->pw_shell));
 
-    char* name = strdup(passwd->pw_name);
-    char* passwdd = strdup(passwd->pw_passwd);
-    char* gecos = strdup(passwd->pw_gecos);
-    char* dir = strdup(passwd->pw_dir);
-    char* shell = strdup(passwd->pw_shell);
-    
-    struct passwd* passwd2 = getpwuid(getuid());
-    ZASSERT(passwd2);
-    ZASSERT(!strcmp(passwd2->pw_name, name));
-    ZASSERT(!strcmp(passwd2->pw_passwd, passwdd));
-    ZASSERT(passwd2->pw_uid == getuid());
-    ZASSERT(passwd2->pw_gid == getgid());
-    ZASSERT(!strcmp(passwd2->pw_gecos, gecos));
-    ZASSERT(!strcmp(passwd2->pw_dir, dir));
-    ZASSERT(!strcmp(passwd2->pw_shell, shell));
+        char* name = strdup(passwd->pw_name);
+        char* passwdd = strdup(passwd->pw_passwd);
+        char* gecos = strdup(passwd->pw_gecos);
+        char* dir = strdup(passwd->pw_dir);
+        char* shell = strdup(passwd->pw_shell);
 
-    passwd = getpwnam(name);
-    ZASSERT(passwd);
-    ZASSERT(!strcmp(passwd->pw_name, name));
-    ZASSERT(!strcmp(passwd->pw_passwd, passwdd));
-    ZASSERT(passwd->pw_uid == getuid());
-    ZASSERT(passwd->pw_gid == getgid());
-    ZASSERT(!strcmp(passwd->pw_gecos, gecos));
-    ZASSERT(!strcmp(passwd->pw_dir, dir));
-    ZASSERT(!strcmp(passwd->pw_shell, shell));
+        struct passwd* passwd2 = getpwuid(getuid());
+        ZASSERT(passwd2);
+        ZASSERT(!strcmp(passwd2->pw_name, name));
+        ZASSERT(!strcmp(passwd2->pw_passwd, passwdd));
+        ZASSERT(passwd2->pw_uid == getuid());
+        ZASSERT(passwd2->pw_gid == getgid());
+        ZASSERT(!strcmp(passwd2->pw_gecos, gecos));
+        ZASSERT(!strcmp(passwd2->pw_dir, dir));
+        ZASSERT(!strcmp(passwd2->pw_shell, shell));
+
+        passwd = getpwnam(name);
+        ZASSERT(passwd);
+        ZASSERT(!strcmp(passwd->pw_name, name));
+        ZASSERT(!strcmp(passwd->pw_passwd, passwdd));
+        ZASSERT(passwd->pw_uid == getuid());
+        ZASSERT(passwd->pw_gid == getgid());
+        ZASSERT(!strcmp(passwd->pw_gecos, gecos));
+        ZASSERT(!strcmp(passwd->pw_dir, dir));
+        ZASSERT(!strcmp(passwd->pw_shell, shell));
+    }
 
     ZASSERT(signal(SIGPIPE, SIG_IGN) == SIG_DFL);
 


### PR DESCRIPTION
The Fil-C libc may not know how to read the local password database (or the user may simply not be in the password database); neither reason is sufficient for the test to fail.