### PR TITLE
Fix implementation of sched_{g,s}etaffinity syscalls

### DIFF
--- a/filc/include/pizlonated_syscalls.h
+++ b/filc/include/pizlonated_syscalls.h
@@ -247,6 +247,7 @@ int zsys_epoll_pwait2(int epfd, void* events, int maxevents, const void* timeout
                       const void* sigmask);
 int zsys_sysinfo(void* info);
 int zsys_sched_getaffinity(int tid, __SIZE_TYPE__ size, void* set);
+int zsys_raw_sched_getaffinity(int tid, __SIZE_TYPE__ size, void* set);
 int zsys_sched_setaffinity(int tid, __SIZE_TYPE__ size, const void* set);
 int zsys_posix_fadvise(int fd, long base, long len, int advice);
 int zsys_ppoll(void* fds, unsigned long nfds, const void* to, const void* mask);

--- a/filc/src/runtime.c
+++ b/filc/src/runtime.c
@@ -589,12 +589,12 @@ long zsys_syscall(long n, ...)
         callee = zsys_keyctl;
         break;
 
-    case 203 /* SYS_sched_getaffinity */:
-        callee = zsys_sched_getaffinity;
+    case 203 /* SYS_sched_setaffinity */:
+        callee = zsys_sched_setaffinity;
         break;
 
-    case 204 /* SYS_sched_setaffinity */:
-        callee = zsys_sched_setaffinity;
+    case 204 /* SYS_sched_getaffinity */:
+        callee = zsys_raw_sched_getaffinity;
         break;
 
     case 248 /* SYS_add_key */:

--- a/libpas/src/libpas/filc_runtime.c
+++ b/libpas/src/libpas/filc_runtime.c
@@ -10501,6 +10501,14 @@ int filc_native_zsys_sched_setaffinity(filc_thread* my_thread, int tid, size_t s
         my_thread, sched_setaffinity(tid, size, (const cpu_set_t*)filc_ptr_ptr(set_ptr)));
 }
 
+int filc_native_zsys_raw_sched_getaffinity(filc_thread* my_thread, int tid, size_t size, filc_ptr set_ptr)
+{
+    filc_check_write(set_ptr, size);
+    return FILC_SYSCALL(my_thread,
+                        syscall(SYS_sched_getaffinity, tid, size,
+                                (unsigned long *)filc_ptr_ptr(set_ptr)));
+}
+
 int filc_native_zsys_sched_getaffinity(filc_thread* my_thread, int tid, size_t size, filc_ptr set_ptr)
 {
     filc_check_write(set_ptr, size);

--- a/libpas/src/libpas/generate_pizlonated_forwarders.rb
+++ b/libpas/src/libpas/generate_pizlonated_forwarders.rb
@@ -384,6 +384,7 @@ addSig "int", "zsys_epoll_pwait_impl", "int", "filc_ptr", "int", "int", "filc_pt
 addSig "int", "zsys_epoll_pwait2_impl", "int", "filc_ptr", "int", "filc_ptr", "filc_ptr"
 addSig "int", "zsys_sysinfo", "filc_ptr"
 addSig "int", "zsys_sched_getaffinity", "int", "size_t", "filc_ptr"
+addSig "int", "zsys_raw_sched_getaffinity", "int", "size_t", "filc_ptr"
 addSig "int", "zsys_sched_setaffinity", "int", "size_t", "filc_ptr"
 addSig "int", "zsys_posix_fadvise", "int", "long", "long", "int"
 addSig "int", "zsys_ppoll", "filc_ptr", "unsigned long", "filc_ptr", "filc_ptr"


### PR DESCRIPTION
- We were using the incorrect syscall numbers, fix that.
- The sched_getaffinity syscall has a different API to the libc function, so expose the syscall API via syscall().