### PR TITLE
Stop asserting that threads are not created during deferred ctors

### DIFF
--- a/filc/tests/concurrentloadstress3/gctor.c
+++ b/filc/tests/concurrentloadstress3/gctor.c
@@ -1,0 +1,17 @@
+#include <stdfil.h>
+#include <unistd.h>
+#include <sched.h>
+#include <stdbool.h>
+
+static void foo(void) __attribute__((constructor));
+
+static void foo(void)
+{
+    zprintf("gctor: gonna sleep a bit.\n");
+    sched_yield();
+    zprintf("gctor: done.\n");
+}
+
+void bar(void)
+{
+}

--- a/filc/tests/concurrentloadstress3/generate-manifest.rb
+++ b/filc/tests/concurrentloadstress3/generate-manifest.rb
@@ -1,0 +1,9 @@
+puts "libraries:"
+1000.times {
+    | index |
+    puts "  gctor#{index}.so:"
+    puts "    isBundle: true"
+    puts "    files:"
+    puts "      - gctor.c"
+}
+

--- a/filc/tests/concurrentloadstress3/loadgctor.c
+++ b/filc/tests/concurrentloadstress3/loadgctor.c
@@ -1,0 +1,53 @@
+#include <stdfil.h>
+#include <dlfcn.h>
+#include <pthread.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+#define N 1000
+
+static void do_stuff(const char* name, const char* so, const char* sym)
+{
+    zprintf("%s: loading %s\n", name, so);
+    void* lib = dlopen(so, RTLD_LAZY | RTLD_LOCAL);
+    zprintf("%s: lib = %p\n", name, lib);
+    if (!lib)
+        zprintf("%s: error: %s\n", name, dlerror());
+    zprintf("%s: dlsymming.\n", name);
+    void (*bar)(void) = dlsym(lib, sym);
+    zprintf("%s: %s = %p\n", name, sym, bar);
+    if (!bar)
+        zprintf("%s: error: %s\n", name, dlerror());
+    zprintf("%s: calling %s.\n", name, sym);
+    bar();
+}
+
+static void* thread_main(void* arg)
+{
+    unsigned i;
+    for (i = N / 2; i--;) {
+        do_stuff(
+            "thread",
+            zasprintf("filc/test-output/concurrentloadstress3/gctor%u.so", i + N / 2),
+            "bar");
+    }
+    return NULL;
+}
+
+int main()
+{
+    return 0;
+}
+
+__attribute__((constructor)) static void foo(void)
+{
+    pthread_t t;
+    pthread_create(&t, NULL, thread_main, NULL);
+
+    unsigned i;
+    for (i = N / 2; i--;)
+        do_stuff("main", zasprintf("filc/test-output/concurrentloadstress3/gctor%u.so", i), "bar");
+
+    pthread_join(t, NULL);
+}
+

--- a/filc/tests/concurrentloadstress3/manifest
+++ b/filc/tests/concurrentloadstress3/manifest
@@ -1,0 +1,4007 @@
+return:
+  success
+slow:
+  true
+extraLinkerArgs:
+  "-rdynamic"
+libraries:
+  gctor0.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor1.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor2.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor3.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor4.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor5.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor6.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor7.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor8.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor9.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor10.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor11.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor12.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor13.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor14.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor15.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor16.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor17.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor18.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor19.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor20.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor21.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor22.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor23.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor24.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor25.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor26.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor27.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor28.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor29.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor30.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor31.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor32.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor33.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor34.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor35.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor36.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor37.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor38.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor39.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor40.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor41.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor42.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor43.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor44.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor45.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor46.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor47.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor48.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor49.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor50.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor51.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor52.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor53.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor54.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor55.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor56.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor57.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor58.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor59.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor60.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor61.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor62.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor63.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor64.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor65.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor66.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor67.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor68.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor69.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor70.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor71.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor72.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor73.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor74.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor75.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor76.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor77.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor78.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor79.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor80.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor81.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor82.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor83.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor84.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor85.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor86.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor87.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor88.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor89.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor90.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor91.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor92.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor93.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor94.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor95.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor96.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor97.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor98.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor99.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor100.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor101.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor102.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor103.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor104.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor105.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor106.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor107.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor108.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor109.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor110.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor111.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor112.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor113.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor114.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor115.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor116.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor117.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor118.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor119.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor120.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor121.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor122.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor123.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor124.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor125.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor126.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor127.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor128.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor129.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor130.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor131.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor132.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor133.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor134.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor135.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor136.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor137.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor138.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor139.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor140.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor141.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor142.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor143.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor144.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor145.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor146.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor147.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor148.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor149.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor150.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor151.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor152.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor153.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor154.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor155.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor156.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor157.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor158.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor159.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor160.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor161.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor162.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor163.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor164.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor165.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor166.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor167.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor168.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor169.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor170.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor171.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor172.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor173.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor174.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor175.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor176.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor177.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor178.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor179.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor180.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor181.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor182.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor183.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor184.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor185.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor186.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor187.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor188.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor189.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor190.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor191.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor192.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor193.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor194.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor195.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor196.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor197.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor198.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor199.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor200.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor201.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor202.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor203.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor204.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor205.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor206.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor207.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor208.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor209.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor210.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor211.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor212.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor213.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor214.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor215.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor216.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor217.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor218.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor219.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor220.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor221.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor222.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor223.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor224.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor225.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor226.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor227.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor228.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor229.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor230.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor231.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor232.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor233.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor234.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor235.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor236.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor237.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor238.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor239.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor240.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor241.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor242.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor243.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor244.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor245.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor246.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor247.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor248.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor249.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor250.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor251.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor252.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor253.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor254.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor255.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor256.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor257.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor258.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor259.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor260.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor261.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor262.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor263.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor264.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor265.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor266.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor267.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor268.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor269.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor270.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor271.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor272.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor273.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor274.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor275.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor276.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor277.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor278.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor279.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor280.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor281.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor282.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor283.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor284.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor285.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor286.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor287.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor288.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor289.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor290.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor291.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor292.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor293.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor294.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor295.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor296.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor297.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor298.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor299.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor300.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor301.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor302.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor303.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor304.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor305.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor306.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor307.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor308.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor309.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor310.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor311.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor312.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor313.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor314.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor315.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor316.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor317.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor318.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor319.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor320.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor321.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor322.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor323.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor324.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor325.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor326.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor327.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor328.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor329.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor330.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor331.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor332.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor333.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor334.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor335.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor336.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor337.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor338.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor339.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor340.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor341.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor342.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor343.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor344.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor345.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor346.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor347.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor348.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor349.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor350.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor351.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor352.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor353.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor354.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor355.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor356.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor357.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor358.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor359.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor360.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor361.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor362.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor363.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor364.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor365.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor366.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor367.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor368.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor369.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor370.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor371.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor372.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor373.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor374.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor375.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor376.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor377.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor378.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor379.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor380.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor381.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor382.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor383.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor384.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor385.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor386.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor387.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor388.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor389.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor390.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor391.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor392.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor393.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor394.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor395.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor396.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor397.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor398.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor399.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor400.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor401.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor402.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor403.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor404.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor405.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor406.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor407.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor408.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor409.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor410.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor411.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor412.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor413.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor414.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor415.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor416.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor417.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor418.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor419.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor420.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor421.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor422.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor423.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor424.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor425.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor426.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor427.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor428.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor429.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor430.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor431.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor432.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor433.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor434.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor435.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor436.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor437.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor438.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor439.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor440.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor441.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor442.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor443.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor444.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor445.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor446.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor447.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor448.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor449.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor450.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor451.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor452.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor453.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor454.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor455.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor456.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor457.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor458.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor459.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor460.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor461.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor462.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor463.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor464.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor465.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor466.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor467.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor468.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor469.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor470.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor471.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor472.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor473.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor474.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor475.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor476.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor477.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor478.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor479.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor480.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor481.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor482.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor483.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor484.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor485.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor486.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor487.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor488.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor489.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor490.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor491.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor492.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor493.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor494.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor495.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor496.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor497.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor498.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor499.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor500.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor501.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor502.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor503.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor504.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor505.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor506.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor507.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor508.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor509.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor510.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor511.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor512.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor513.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor514.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor515.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor516.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor517.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor518.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor519.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor520.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor521.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor522.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor523.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor524.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor525.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor526.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor527.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor528.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor529.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor530.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor531.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor532.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor533.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor534.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor535.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor536.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor537.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor538.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor539.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor540.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor541.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor542.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor543.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor544.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor545.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor546.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor547.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor548.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor549.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor550.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor551.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor552.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor553.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor554.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor555.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor556.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor557.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor558.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor559.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor560.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor561.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor562.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor563.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor564.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor565.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor566.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor567.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor568.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor569.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor570.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor571.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor572.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor573.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor574.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor575.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor576.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor577.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor578.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor579.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor580.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor581.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor582.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor583.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor584.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor585.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor586.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor587.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor588.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor589.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor590.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor591.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor592.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor593.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor594.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor595.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor596.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor597.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor598.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor599.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor600.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor601.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor602.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor603.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor604.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor605.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor606.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor607.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor608.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor609.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor610.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor611.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor612.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor613.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor614.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor615.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor616.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor617.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor618.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor619.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor620.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor621.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor622.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor623.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor624.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor625.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor626.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor627.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor628.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor629.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor630.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor631.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor632.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor633.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor634.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor635.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor636.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor637.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor638.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor639.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor640.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor641.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor642.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor643.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor644.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor645.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor646.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor647.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor648.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor649.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor650.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor651.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor652.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor653.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor654.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor655.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor656.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor657.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor658.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor659.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor660.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor661.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor662.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor663.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor664.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor665.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor666.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor667.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor668.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor669.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor670.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor671.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor672.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor673.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor674.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor675.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor676.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor677.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor678.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor679.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor680.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor681.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor682.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor683.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor684.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor685.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor686.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor687.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor688.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor689.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor690.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor691.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor692.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor693.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor694.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor695.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor696.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor697.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor698.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor699.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor700.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor701.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor702.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor703.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor704.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor705.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor706.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor707.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor708.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor709.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor710.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor711.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor712.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor713.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor714.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor715.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor716.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor717.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor718.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor719.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor720.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor721.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor722.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor723.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor724.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor725.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor726.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor727.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor728.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor729.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor730.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor731.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor732.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor733.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor734.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor735.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor736.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor737.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor738.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor739.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor740.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor741.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor742.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor743.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor744.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor745.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor746.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor747.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor748.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor749.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor750.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor751.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor752.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor753.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor754.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor755.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor756.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor757.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor758.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor759.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor760.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor761.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor762.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor763.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor764.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor765.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor766.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor767.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor768.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor769.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor770.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor771.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor772.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor773.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor774.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor775.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor776.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor777.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor778.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor779.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor780.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor781.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor782.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor783.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor784.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor785.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor786.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor787.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor788.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor789.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor790.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor791.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor792.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor793.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor794.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor795.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor796.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor797.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor798.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor799.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor800.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor801.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor802.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor803.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor804.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor805.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor806.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor807.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor808.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor809.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor810.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor811.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor812.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor813.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor814.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor815.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor816.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor817.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor818.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor819.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor820.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor821.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor822.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor823.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor824.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor825.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor826.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor827.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor828.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor829.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor830.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor831.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor832.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor833.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor834.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor835.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor836.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor837.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor838.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor839.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor840.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor841.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor842.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor843.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor844.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor845.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor846.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor847.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor848.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor849.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor850.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor851.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor852.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor853.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor854.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor855.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor856.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor857.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor858.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor859.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor860.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor861.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor862.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor863.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor864.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor865.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor866.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor867.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor868.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor869.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor870.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor871.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor872.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor873.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor874.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor875.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor876.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor877.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor878.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor879.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor880.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor881.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor882.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor883.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor884.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor885.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor886.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor887.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor888.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor889.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor890.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor891.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor892.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor893.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor894.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor895.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor896.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor897.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor898.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor899.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor900.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor901.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor902.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor903.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor904.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor905.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor906.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor907.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor908.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor909.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor910.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor911.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor912.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor913.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor914.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor915.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor916.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor917.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor918.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor919.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor920.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor921.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor922.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor923.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor924.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor925.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor926.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor927.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor928.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor929.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor930.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor931.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor932.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor933.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor934.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor935.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor936.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor937.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor938.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor939.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor940.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor941.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor942.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor943.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor944.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor945.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor946.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor947.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor948.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor949.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor950.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor951.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor952.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor953.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor954.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor955.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor956.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor957.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor958.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor959.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor960.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor961.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor962.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor963.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor964.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor965.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor966.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor967.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor968.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor969.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor970.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor971.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor972.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor973.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor974.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor975.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor976.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor977.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor978.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor979.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor980.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor981.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor982.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor983.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor984.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor985.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor986.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor987.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor988.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor989.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor990.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor991.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor992.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor993.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor994.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor995.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor996.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor997.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor998.so:
+    isBundle: true
+    files:
+      - gctor.c
+  gctor999.so:
+    isBundle: true
+    files:
+      - gctor.c

--- a/libpas/src/libpas/filc_runtime.c
+++ b/libpas/src/libpas/filc_runtime.c
@@ -12560,7 +12560,6 @@ bool filc_native_zthread_create2(filc_thread* my_thread, filc_ptr callback_ptr, 
         filc_did_run_deferred_global_ctors,
         NULL,
         "cannot create threads before global constructors have started being run.");
-    PAS_ASSERT(filc_did_clear_deferred_global_ctors);
     filc_check_function_call(callback_ptr);
     filc_thread* thread = filc_thread_create_with_manual_tracking(my_thread);
     filc_thread_track_object(my_thread, filc_object_for_special_payload(thread));


### PR DESCRIPTION
It's valid for constructors to create threads, so we should allow it. A potentially problematic case (already handled by locking the deferred constructor list) is where the constructor calls dlopen and triggers further constructor calls, so add test coverage for it, The new test is just a copy of filc/tests/concurrentloadstress with the body of main() moved to a constructor.