### PR TITLE
Add a build_tar.sh script

### DIFF
--- a/build_tar.sh
+++ b/build_tar.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+#
+# Copyright (c) 2025 Epic Games, Inc. All Rights Reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY EPIC GAMES, INC. ``AS IS AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL EPIC GAMES, INC. OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+
+. libpas/common.sh
+
+set -e
+set -x
+
+cd projects/tar-1.35
+extract_source
+CC=$PWD/../../../build/bin/clang CXX=$PWD/../../../build/bin/clang++ ./configure --prefix=$PWD/../../../pizfix
+make -j $NCPU
+make -j $NCPU install
+
+../../../pizfix/bin/tar -czf filc-test-output.tar.gz ./tests/
+
+if [ "$(du -sb ./tests | awk '{print $1}')" -gt "$(du -b filc-test-output.tar.gz | awk '{print $1}')" ]; then
+    echo "size is smaller, as we expect"
+else
+    echo "size is not smaller"
+    exit 1
+fi
+
+mkdir fil-test-output-extracted
+tar -xzf filc-test-output.tar.gz -C fil-test-output-extracted
+diff -r tests fil-test-output-extracted/tests
+rm -f filc-test-output.tar.gz 
+rm -rf fil-test-output-extracted


### PR DESCRIPTION
Add a script to make building tar easier.

Phil, is there anything I need to do to test that this works in the container/other environments? I just ran this in my normal dev environment.