### PR TITLE
This patch makes it so obstack allocates a single object per chunk.

### DIFF
--- a/filc/tests/obstack-oob/manifest
+++ b/filc/tests/obstack-oob/manifest
@@ -1,0 +1,4 @@
+return:
+  failure
+output-includes:
+  - "filc safety error: cannot write pointer with ptr >= upper."

--- a/filc/tests/obstack-oob/obstack-oob.c
+++ b/filc/tests/obstack-oob/obstack-oob.c
@@ -1,0 +1,28 @@
+#define _GNU_SOURCE
+#include <features.h>
+
+#ifdef __USE_GNU
+
+#include <stdfil.h>
+#include <stdlib.h>
+#include <obstack.h>
+#include <stddef.h>
+
+#define obstack_chunk_alloc malloc
+#define obstack_chunk_free free
+
+int main()
+{
+    // Ensure we get different allocations per each object allocated from an obstack.
+    struct obstack o;
+    obstack_init(&o);
+
+    char* p1 = obstack_alloc(&o, 1);
+    char* p2 = obstack_alloc(&o, 1);
+    ptrdiff_t delta = p2 - p1;
+    *(p1 + delta) = 'z';
+
+    return 0;
+}
+
+#endif // __USE_GNU

--- a/filc/tests/obstack/manifest
+++ b/filc/tests/obstack/manifest
@@ -1,0 +1,2 @@
+return:
+  success

--- a/filc/tests/obstack/obstack.c
+++ b/filc/tests/obstack/obstack.c
@@ -1,0 +1,32 @@
+#define _GNU_SOURCE
+#include <features.h>
+
+#ifdef __USE_GNU
+
+#include <stdfil.h>
+#include <stdlib.h>
+#include <obstack.h>
+
+#define obstack_chunk_alloc malloc
+#define obstack_chunk_free free
+
+int main()
+{
+    // This test models code that needs to work this way for binutils to work.
+    struct obstack o;
+    obstack_init(&o);
+
+    size_t a = 42;
+    size_t b = 666;
+
+    obstack_blank(&o, a + b);
+    void* ptr = obstack_base(&o);
+    ZASSERT(!!ptr);
+    o.next_free -= b;
+    obstack_finish(&o);
+    ZASSERT(obstack_room(&o) >= b);
+
+    return 0;
+}
+
+#endif // __USE_GNU

--- a/projects/binutils-2.43.1/gas/frags.c
+++ b/projects/binutils-2.43.1/gas/frags.c
@@ -72,8 +72,8 @@ frag_alloc_check (const struct obstack *ob)
    Call this routine from everywhere else, so that all the weird alignment
    hackery can be done in just one place.  */
 
-fragS *
-frag_alloc (struct obstack *ob)
+static fragS *
+frag_alloc_impl (struct obstack *ob, size_t size)
 {
   fragS *ptr;
   int oalign;
@@ -81,62 +81,24 @@ frag_alloc (struct obstack *ob)
   (void) obstack_alloc (ob, 0);
   oalign = obstack_alignment_mask (ob);
   obstack_alignment_mask (ob) = 0;
-  ptr = (fragS *) obstack_alloc (ob, SIZEOF_STRUCT_FRAG);
+
+  obstack_blank (ob, SIZEOF_STRUCT_FRAG + size);
+  ptr = (fragS *)obstack_base (ob);
+  ob->next_free -= size;
+  obstack_finish (ob);
+
   obstack_alignment_mask (ob) = oalign;
   memset (ptr, 0, SIZEOF_STRUCT_FRAG);
   totalfrags++;
   return ptr;
 }
-
-/* Try to augment current frag by nchars chars.
-   If there is no room, close off the current frag with a ".fill 0"
-   and begin a new frag.  Then loop until the new frag has at least
-   nchars chars available.  Does not set up any fields in frag_now.  */
 
-void
-frag_grow (size_t nchars)
+fragS *
+frag_alloc (struct obstack *ob)
 {
-  if (obstack_room (&frchain_now->frch_obstack) < nchars)
-    {
-      size_t oldc;
-      size_t newc;
-
-      /* Try to allocate a bit more than needed right now.  But don't do
-         this if we would waste too much memory.  Especially necessary
-         for extremely big (like 2GB initialized) frags.  */
-      if (nchars < 0x10000)
-        newc = 2 * nchars;
-      else
-        newc = nchars + 0x10000;
-      newc += SIZEOF_STRUCT_FRAG;
-
-      /* Check for possible overflow.  */
-      if (newc < nchars)
-	as_fatal (ngettext ("can't extend frag %lu char",
-			    "can't extend frag %lu chars",
-			    (unsigned long) nchars),
-		  (unsigned long) nchars);
-
-      /* Force to allocate at least NEWC bytes, but not less than the
-         default.  */
-      oldc = obstack_chunk_size (&frchain_now->frch_obstack);
-      if (newc > oldc)
-	obstack_chunk_size (&frchain_now->frch_obstack) = newc;
-
-      while (obstack_room (&frchain_now->frch_obstack) < nchars)
-        {
-          /* Not enough room in this frag.  Close it and start a new one.
-             This must be done in a loop because the created frag may not
-             be big enough if the current obstack chunk is used.  */
-          frag_wane (frag_now);
-          frag_new (0);
-        }
-
-      /* Restore the old chunk size.  */
-      obstack_chunk_size (&frchain_now->frch_obstack) = oldc;
-    }
+  return frag_alloc_impl(ob, 100);
 }
-
+
 /* Call this to close off a completed frag, and start up a new (empty)
    frag, in the same subsegment as the old frag.
    [frchain_now remains the same but frag_now is updated.]
@@ -154,10 +116,8 @@ frag_grow (size_t nchars)
    Make a new frag, initialising some components. Link new frag at end
    of frchain_now.  */
 
-void
-frag_new (size_t old_frags_var_max_size
-	  /* Number of chars (already allocated on obstack frags) in
-	     variable_length part of frag.  */)
+static void 
+frag_new_impl (size_t old_frags_var_max_size, size_t new_frag_size)
 {
   fragS *former_last_fragP;
   frchainS *frchP;
@@ -180,7 +140,7 @@ frag_new (size_t old_frags_var_max_size
   former_last_fragP = frchP->frch_last;
   gas_assert (former_last_fragP != 0);
   gas_assert (former_last_fragP == frag_now);
-  frag_now = frag_alloc (&frchP->frch_obstack);
+  frag_now = frag_alloc_impl (&frchP->frch_obstack, new_frag_size);
 
   frag_now->fr_file = as_where (&frag_now->fr_line);
 
@@ -202,6 +162,57 @@ frag_new (size_t old_frags_var_max_size
 
   frag_now->fr_next = NULL;
 }
+
+void
+frag_new (size_t old_frags_var_max_size
+	  /* Number of chars (already allocated on obstack frags) in
+	     variable_length part of frag.  */)
+{
+  frag_new_impl(old_frags_var_max_size, 100);
+}
+
+/* Try to augment current frag by nchars chars.
+   If there is no room, close off the current frag with a ".fill 0"
+   and begin a new frag.  Then loop until the new frag has at least
+   nchars chars available.  Does not set up any fields in frag_now.  */
+
+void
+frag_grow (size_t nchars)
+{
+  if (obstack_room (&frchain_now->frch_obstack) < nchars)
+    {
+      size_t newc;
+
+      /* Try to allocate a bit more than needed right now.  But don't do
+         this if we would waste too much memory.  Especially necessary
+         for extremely big (like 2GB initialized) frags.  */
+      if (nchars < 0x10000)
+        newc = 2 * nchars;
+      else
+        newc = nchars + 0x10000;
+      newc += SIZEOF_STRUCT_FRAG;
+
+      /* Check for possible overflow.  */
+      if (newc < nchars)
+	as_fatal (ngettext ("can't extend frag %lu char",
+			    "can't extend frag %lu chars",
+			    (unsigned long) nchars),
+		  (unsigned long) nchars);
+
+      /* Force to allocate at least NEWC bytes, but not less than the
+         default.  */
+
+      while (obstack_room (&frchain_now->frch_obstack) < nchars)
+        {
+          /* Not enough room in this frag.  Close it and start a new one.
+             This must be done in a loop because the created frag may not
+             be big enough if the current obstack chunk is used.  */
+          frag_wane (frag_now);
+          frag_new_impl (0, nchars);
+        }
+    }
+}
+
 
 /* Start a new frag unless we have n more chars of room in the current frag.
    Close off the old frag with a .fill 0.

--- a/projects/binutils-2.43.1/include/obstack.h
+++ b/projects/binutils-2.43.1/include/obstack.h
@@ -376,8 +376,7 @@ extern int obstack_exit_failure;
   __extension__								      \
     ({ struct obstack *__o = (OBSTACK);					      \
        _OBSTACK_SIZE_T __len = (length);				      \
-       if (obstack_room (__o) < __len)					      \
-         _obstack_newchunk (__o, __len);				      \
+       _obstack_newchunk (__o, __len);				      \
        obstack_blank_fast (__o, __len); })
 
 # define obstack_alloc(OBSTACK, length)					      \
@@ -492,8 +491,7 @@ extern int obstack_exit_failure;
 
 # define obstack_blank(h, length)					      \
   ((h)->temp.i = (length),						      \
-   ((obstack_room (h) < (h)->temp.i)					      \
-   ? (_obstack_newchunk ((h), (h)->temp.i), 0) : 0),			      \
+   _obstack_newchunk ((h), (h)->temp.i),			      \
    obstack_blank_fast (h, (h)->temp.i))
 
 # define obstack_alloc(h, length)					      \

--- a/projects/binutils-2.43.1/libiberty/obstack.c
+++ b/projects/binutils-2.43.1/libiberty/obstack.c
@@ -118,25 +118,10 @@ _obstack_begin_worker (struct obstack *h,
 
   if (alignment == 0)
     alignment = DEFAULT_ALIGNMENT;
-  if (size == 0)
-    /* Default size is what GNU malloc can fit in a 4096-byte block.  */
-    {
-      /* 12 is sizeof (mhead) and 4 is EXTRA from GNU malloc.
-         Use the values for range checking, because if range checking is off,
-         the extra bytes won't be missed terribly, but if range checking is on
-         and we used a larger request, a whole extra 4096 bytes would be
-         allocated.
 
-         These number are irrelevant to the new GNU malloc.  I suspect it is
-         less sensitive to the size of the request.  */
-      int extra = ((((12 + DEFAULT_ROUNDING - 1) & ~(DEFAULT_ROUNDING - 1))
-                    + 4 + DEFAULT_ROUNDING - 1)
-                   & ~(DEFAULT_ROUNDING - 1));
-      size = 4096 - extra;
-    }
-
-  h->chunk_size = size;
   h->alignment_mask = alignment - 1;
+  size = sizeof(struct _obstack_chunk) + h->alignment_mask;
+  h->chunk_size = size;
 
   chunk = (struct _obstack_chunk *) call_chunkfun (h, h->chunk_size);
   if (!chunk)
@@ -190,19 +175,18 @@ _obstack_newchunk (struct obstack *h, _OBSTACK_SIZE_T length)
   struct _obstack_chunk *old_chunk = h->chunk;
   struct _obstack_chunk *new_chunk = 0;
   size_t obj_size = h->next_free - h->object_base;
+  size_t new_size;
   char *object_base;
 
   /* Compute size for new chunk.  */
-  size_t sum1 = obj_size + length;
-  size_t sum2 = sum1 + h->alignment_mask;
-  size_t new_size = sum2 + (obj_size >> 3) + 100;
-  if (new_size < sum2)
-    new_size = sum2;
-  if (new_size < h->chunk_size)
-    new_size = h->chunk_size;
+  if (obj_size)
+    new_size = 2 * (obj_size + length);
+  else
+    new_size = length;
+  new_size += sizeof (struct _obstack_chunk) + h->alignment_mask;
 
   /* Allocate and initialize the new chunk.  */
-  if (obj_size <= sum1 && sum1 <= sum2)
+  if (new_size >= length && new_size >= obj_size)
     new_chunk = (struct _obstack_chunk *) call_chunkfun (h, new_size);
   if (!new_chunk)
     (*obstack_alloc_failed_handler)();

--- a/projects/bison-3.8.2/lib/obstack.c
+++ b/projects/bison-3.8.2/lib/obstack.c
@@ -112,25 +112,11 @@ _obstack_begin_worker (struct obstack *h,
 
   if (alignment == 0)
     alignment = DEFAULT_ALIGNMENT;
-  if (size == 0)
-    /* Default size is what GNU malloc can fit in a 4096-byte block.  */
-    {
-      /* 12 is sizeof (mhead) and 4 is EXTRA from GNU malloc.
-         Use the values for range checking, because if range checking is off,
-         the extra bytes won't be missed terribly, but if range checking is on
-         and we used a larger request, a whole extra 4096 bytes would be
-         allocated.
 
-         These number are irrelevant to the new GNU malloc.  I suspect it is
-         less sensitive to the size of the request.  */
-      int extra = ((((12 + DEFAULT_ROUNDING - 1) & ~(DEFAULT_ROUNDING - 1))
-                    + 4 + DEFAULT_ROUNDING - 1)
-                   & ~(DEFAULT_ROUNDING - 1));
-      size = 4096 - extra;
-    }
-
-  h->chunk_size = size;
   h->alignment_mask = alignment - 1;
+
+  size = sizeof (struct _obstack_chunk) + h->alignment_mask;
+  h->chunk_size = size;
 
   chunk = h->chunk = call_chunkfun (h, h->chunk_size);
   if (!chunk)
@@ -186,19 +172,19 @@ _obstack_newchunk (struct obstack *h, _OBSTACK_SIZE_T length)
   char *object_base;
 
   /* Compute size for new chunk.  */
-  size_t sum1 = obj_size + length;
-  size_t sum2 = sum1 + h->alignment_mask;
-  size_t new_size = sum2 + (obj_size >> 3) + 100;
-  if (new_size < sum2)
-    new_size = sum2;
-  if (new_size < h->chunk_size)
-    new_size = h->chunk_size;
+  size_t new_size;
+  if (obj_size)
+    new_size = 2 * (obj_size + length);
+  else
+    new_size = length;
+  new_size += sizeof (struct _obstack_chunk) + h->alignment_mask;
 
   /* Allocate and initialize the new chunk.  */
-  if (obj_size <= sum1 && sum1 <= sum2)
+  if (new_size >= length && new_size >= obj_size)
     new_chunk = call_chunkfun (h, new_size);
   if (!new_chunk)
     (*obstack_alloc_failed_handler)();
+
   h->chunk = new_chunk;
   new_chunk->prev = old_chunk;
   new_chunk->limit = h->chunk_limit = (char *) new_chunk + new_size;

--- a/projects/bison-3.8.2/lib/obstack.h
+++ b/projects/bison-3.8.2/lib/obstack.h
@@ -392,8 +392,7 @@ extern int obstack_exit_failure;
   __extension__								      \
     ({ struct obstack *__o = (OBSTACK);					      \
        _OBSTACK_SIZE_T __len = (length);				      \
-       if (obstack_room (__o) < __len)					      \
-         _obstack_newchunk (__o, __len);				      \
+       _obstack_newchunk (__o, __len);				      \
        obstack_blank_fast (__o, __len); })
 
 # define obstack_alloc(OBSTACK, length)					      \
@@ -508,8 +507,7 @@ extern int obstack_exit_failure;
 
 # define obstack_blank(h, length)					      \
   ((h)->temp.i = (length),						      \
-   ((obstack_room (h) < (h)->temp.i)					      \
-   ? (_obstack_newchunk ((h), (h)->temp.i), 0) : 0),			      \
+   _obstack_newchunk ((h), (h)->temp.i),			      \
    obstack_blank_fast (h, (h)->temp.i))
 
 # define obstack_alloc(h, length)					      \

--- a/projects/coreutils-9.5/lib/obstack.c
+++ b/projects/coreutils-9.5/lib/obstack.c
@@ -92,25 +92,11 @@ _obstack_begin_worker (struct obstack *h,
 
   if (alignment == 0)
     alignment = DEFAULT_ALIGNMENT;
-  if (size == 0)
-    /* Default size is what GNU malloc can fit in a 4096-byte block.  */
-    {
-      /* 12 is sizeof (mhead) and 4 is EXTRA from GNU malloc.
-         Use the values for range checking, because if range checking is off,
-         the extra bytes won't be missed terribly, but if range checking is on
-         and we used a larger request, a whole extra 4096 bytes would be
-         allocated.
 
-         These number are irrelevant to the new GNU malloc.  I suspect it is
-         less sensitive to the size of the request.  */
-      int extra = ((((12 + DEFAULT_ROUNDING - 1) & ~(DEFAULT_ROUNDING - 1))
-                    + 4 + DEFAULT_ROUNDING - 1)
-                   & ~(DEFAULT_ROUNDING - 1));
-      size = 4096 - extra;
-    }
-
-  h->chunk_size = size;
   h->alignment_mask = alignment - 1;
+
+  size = sizeof (struct _obstack_chunk) + h->alignment_mask;
+  h->chunk_size = size;
 
   chunk = h->chunk = call_chunkfun (h, h->chunk_size);
   if (!chunk)
@@ -166,19 +152,19 @@ _obstack_newchunk (struct obstack *h, _OBSTACK_SIZE_T length)
   char *object_base;
 
   /* Compute size for new chunk.  */
-  size_t sum1 = obj_size + length;
-  size_t sum2 = sum1 + h->alignment_mask;
-  size_t new_size = sum2 + (obj_size >> 3) + 100;
-  if (new_size < sum2)
-    new_size = sum2;
-  if (new_size < h->chunk_size)
-    new_size = h->chunk_size;
+  size_t new_size;
+  if (obj_size)
+    new_size = 2 * (obj_size + length);
+  else
+    new_size = length;
+  new_size += sizeof (struct _obstack_chunk) + h->alignment_mask;
 
   /* Allocate and initialize the new chunk.  */
-  if (obj_size <= sum1 && sum1 <= sum2)
+  if (new_size >= length && new_size >= obj_size)
     new_chunk = call_chunkfun (h, new_size);
   if (!new_chunk)
     (*obstack_alloc_failed_handler)();
+
   h->chunk = new_chunk;
   new_chunk->prev = old_chunk;
   new_chunk->limit = h->chunk_limit = (char *) new_chunk + new_size;

--- a/projects/coreutils-9.5/lib/obstack.in.h
+++ b/projects/coreutils-9.5/lib/obstack.in.h
@@ -394,8 +394,7 @@ extern int obstack_exit_failure;
   __extension__								      \
     ({ struct obstack *__o = (OBSTACK);					      \
        _OBSTACK_SIZE_T __len = (length);				      \
-       if (obstack_room (__o) < __len)					      \
-         _obstack_newchunk (__o, __len);				      \
+       _obstack_newchunk (__o, __len);				      \
        obstack_blank_fast (__o, __len); })
 
 # define obstack_alloc(OBSTACK, length)					      \
@@ -510,8 +509,7 @@ extern int obstack_exit_failure;
 
 # define obstack_blank(h, length)					      \
   ((h)->temp.i = (length),						      \
-   ((obstack_room (h) < (h)->temp.i)					      \
-   ? (_obstack_newchunk ((h), (h)->temp.i), 0) : 0),			      \
+   _obstack_newchunk ((h), (h)->temp.i),			      \
    obstack_blank_fast (h, (h)->temp.i))
 
 # define obstack_alloc(h, length)					      \

--- a/projects/gettext-0.22.5/gettext-tools/gnulib-lib/obstack.c
+++ b/projects/gettext-0.22.5/gettext-tools/gnulib-lib/obstack.c
@@ -92,25 +92,11 @@ _obstack_begin_worker (struct obstack *h,
 
   if (alignment == 0)
     alignment = DEFAULT_ALIGNMENT;
-  if (size == 0)
-    /* Default size is what GNU malloc can fit in a 4096-byte block.  */
-    {
-      /* 12 is sizeof (mhead) and 4 is EXTRA from GNU malloc.
-         Use the values for range checking, because if range checking is off,
-         the extra bytes won't be missed terribly, but if range checking is on
-         and we used a larger request, a whole extra 4096 bytes would be
-         allocated.
 
-         These number are irrelevant to the new GNU malloc.  I suspect it is
-         less sensitive to the size of the request.  */
-      int extra = ((((12 + DEFAULT_ROUNDING - 1) & ~(DEFAULT_ROUNDING - 1))
-                    + 4 + DEFAULT_ROUNDING - 1)
-                   & ~(DEFAULT_ROUNDING - 1));
-      size = 4096 - extra;
-    }
-
-  h->chunk_size = size;
   h->alignment_mask = alignment - 1;
+
+  size = sizeof (struct _obstack_chunk) + h->alignment_mask;
+  h->chunk_size = size;
 
   chunk = h->chunk = call_chunkfun (h, h->chunk_size);
   if (!chunk)
@@ -166,19 +152,19 @@ _obstack_newchunk (struct obstack *h, _OBSTACK_SIZE_T length)
   char *object_base;
 
   /* Compute size for new chunk.  */
-  size_t sum1 = obj_size + length;
-  size_t sum2 = sum1 + h->alignment_mask;
-  size_t new_size = sum2 + (obj_size >> 3) + 100;
-  if (new_size < sum2)
-    new_size = sum2;
-  if (new_size < h->chunk_size)
-    new_size = h->chunk_size;
+  size_t new_size;
+  if (obj_size)
+    new_size = 2 * (obj_size + length);
+  else
+    new_size = length;
+  new_size += sizeof (struct _obstack_chunk) + h->alignment_mask;
 
   /* Allocate and initialize the new chunk.  */
-  if (obj_size <= sum1 && sum1 <= sum2)
+  if (new_size >= length && new_size >= obj_size)
     new_chunk = call_chunkfun (h, new_size);
   if (!new_chunk)
     (*obstack_alloc_failed_handler)();
+
   h->chunk = new_chunk;
   new_chunk->prev = old_chunk;
   new_chunk->limit = h->chunk_limit = (char *) new_chunk + new_size;

--- a/projects/gettext-0.22.5/gettext-tools/gnulib-lib/obstack.in.h
+++ b/projects/gettext-0.22.5/gettext-tools/gnulib-lib/obstack.in.h
@@ -394,8 +394,7 @@ extern int obstack_exit_failure;
   __extension__								      \
     ({ struct obstack *__o = (OBSTACK);					      \
        _OBSTACK_SIZE_T __len = (length);				      \
-       if (obstack_room (__o) < __len)					      \
-         _obstack_newchunk (__o, __len);				      \
+       _obstack_newchunk (__o, __len);				      \
        obstack_blank_fast (__o, __len); })
 
 # define obstack_alloc(OBSTACK, length)					      \
@@ -510,8 +509,7 @@ extern int obstack_exit_failure;
 
 # define obstack_blank(h, length)					      \
   ((h)->temp.i = (length),						      \
-   ((obstack_room (h) < (h)->temp.i)					      \
-   ? (_obstack_newchunk ((h), (h)->temp.i), 0) : 0),			      \
+   _obstack_newchunk ((h), (h)->temp.i),			      \
    obstack_blank_fast (h, (h)->temp.i))
 
 # define obstack_alloc(h, length)					      \

--- a/projects/gettext-0.22.5/gettext-tools/libgettextpo/obstack.c
+++ b/projects/gettext-0.22.5/gettext-tools/libgettextpo/obstack.c
@@ -92,25 +92,11 @@ _obstack_begin_worker (struct obstack *h,
 
   if (alignment == 0)
     alignment = DEFAULT_ALIGNMENT;
-  if (size == 0)
-    /* Default size is what GNU malloc can fit in a 4096-byte block.  */
-    {
-      /* 12 is sizeof (mhead) and 4 is EXTRA from GNU malloc.
-         Use the values for range checking, because if range checking is off,
-         the extra bytes won't be missed terribly, but if range checking is on
-         and we used a larger request, a whole extra 4096 bytes would be
-         allocated.
 
-         These number are irrelevant to the new GNU malloc.  I suspect it is
-         less sensitive to the size of the request.  */
-      int extra = ((((12 + DEFAULT_ROUNDING - 1) & ~(DEFAULT_ROUNDING - 1))
-                    + 4 + DEFAULT_ROUNDING - 1)
-                   & ~(DEFAULT_ROUNDING - 1));
-      size = 4096 - extra;
-    }
-
-  h->chunk_size = size;
   h->alignment_mask = alignment - 1;
+
+  size = sizeof (struct _obstack_chunk) + h->alignment_mask;
+  h->chunk_size = size;
 
   chunk = h->chunk = call_chunkfun (h, h->chunk_size);
   if (!chunk)
@@ -166,19 +152,19 @@ _obstack_newchunk (struct obstack *h, _OBSTACK_SIZE_T length)
   char *object_base;
 
   /* Compute size for new chunk.  */
-  size_t sum1 = obj_size + length;
-  size_t sum2 = sum1 + h->alignment_mask;
-  size_t new_size = sum2 + (obj_size >> 3) + 100;
-  if (new_size < sum2)
-    new_size = sum2;
-  if (new_size < h->chunk_size)
-    new_size = h->chunk_size;
+  size_t new_size;
+  if (obj_size)
+    new_size = 2 * (obj_size + length);
+  else
+    new_size = length;
+  new_size += sizeof (struct _obstack_chunk) + h->alignment_mask;
 
   /* Allocate and initialize the new chunk.  */
-  if (obj_size <= sum1 && sum1 <= sum2)
+  if (new_size >= length && new_size >= obj_size)
     new_chunk = call_chunkfun (h, new_size);
   if (!new_chunk)
     (*obstack_alloc_failed_handler)();
+
   h->chunk = new_chunk;
   new_chunk->prev = old_chunk;
   new_chunk->limit = h->chunk_limit = (char *) new_chunk + new_size;

--- a/projects/gettext-0.22.5/gettext-tools/libgettextpo/obstack.in.h
+++ b/projects/gettext-0.22.5/gettext-tools/libgettextpo/obstack.in.h
@@ -394,8 +394,7 @@ extern int obstack_exit_failure;
   __extension__								      \
     ({ struct obstack *__o = (OBSTACK);					      \
        _OBSTACK_SIZE_T __len = (length);				      \
-       if (obstack_room (__o) < __len)					      \
-         _obstack_newchunk (__o, __len);				      \
+       _obstack_newchunk (__o, __len);				      \
        obstack_blank_fast (__o, __len); })
 
 # define obstack_alloc(OBSTACK, length)					      \
@@ -510,8 +509,7 @@ extern int obstack_exit_failure;
 
 # define obstack_blank(h, length)					      \
   ((h)->temp.i = (length),						      \
-   ((obstack_room (h) < (h)->temp.i)					      \
-   ? (_obstack_newchunk ((h), (h)->temp.i), 0) : 0),			      \
+   _obstack_newchunk ((h), (h)->temp.i),			      \
    obstack_blank_fast (h, (h)->temp.i))
 
 # define obstack_alloc(h, length)					      \

--- a/projects/gettext-0.22.5/libtextstyle/lib/obstack.c
+++ b/projects/gettext-0.22.5/libtextstyle/lib/obstack.c
@@ -92,25 +92,11 @@ _obstack_begin_worker (struct obstack *h,
 
   if (alignment == 0)
     alignment = DEFAULT_ALIGNMENT;
-  if (size == 0)
-    /* Default size is what GNU malloc can fit in a 4096-byte block.  */
-    {
-      /* 12 is sizeof (mhead) and 4 is EXTRA from GNU malloc.
-         Use the values for range checking, because if range checking is off,
-         the extra bytes won't be missed terribly, but if range checking is on
-         and we used a larger request, a whole extra 4096 bytes would be
-         allocated.
 
-         These number are irrelevant to the new GNU malloc.  I suspect it is
-         less sensitive to the size of the request.  */
-      int extra = ((((12 + DEFAULT_ROUNDING - 1) & ~(DEFAULT_ROUNDING - 1))
-                    + 4 + DEFAULT_ROUNDING - 1)
-                   & ~(DEFAULT_ROUNDING - 1));
-      size = 4096 - extra;
-    }
-
-  h->chunk_size = size;
   h->alignment_mask = alignment - 1;
+
+  size = sizeof (struct _obstack_chunk) + h->alignment_mask;
+  h->chunk_size = size;
 
   chunk = h->chunk = call_chunkfun (h, h->chunk_size);
   if (!chunk)
@@ -166,19 +152,19 @@ _obstack_newchunk (struct obstack *h, _OBSTACK_SIZE_T length)
   char *object_base;
 
   /* Compute size for new chunk.  */
-  size_t sum1 = obj_size + length;
-  size_t sum2 = sum1 + h->alignment_mask;
-  size_t new_size = sum2 + (obj_size >> 3) + 100;
-  if (new_size < sum2)
-    new_size = sum2;
-  if (new_size < h->chunk_size)
-    new_size = h->chunk_size;
+  size_t new_size;
+  if (obj_size)
+    new_size = 2 * (obj_size + length);
+  else
+    new_size = length;
+  new_size += sizeof (struct _obstack_chunk) + h->alignment_mask;
 
   /* Allocate and initialize the new chunk.  */
-  if (obj_size <= sum1 && sum1 <= sum2)
+  if (new_size >= length && new_size >= obj_size)
     new_chunk = call_chunkfun (h, new_size);
   if (!new_chunk)
     (*obstack_alloc_failed_handler)();
+
   h->chunk = new_chunk;
   new_chunk->prev = old_chunk;
   new_chunk->limit = h->chunk_limit = (char *) new_chunk + new_size;

--- a/projects/gettext-0.22.5/libtextstyle/lib/obstack.in.h
+++ b/projects/gettext-0.22.5/libtextstyle/lib/obstack.in.h
@@ -394,8 +394,7 @@ extern int obstack_exit_failure;
   __extension__								      \
     ({ struct obstack *__o = (OBSTACK);					      \
        _OBSTACK_SIZE_T __len = (length);				      \
-       if (obstack_room (__o) < __len)					      \
-         _obstack_newchunk (__o, __len);				      \
+       _obstack_newchunk (__o, __len);				      \
        obstack_blank_fast (__o, __len); })
 
 # define obstack_alloc(OBSTACK, length)					      \
@@ -510,8 +509,7 @@ extern int obstack_exit_failure;
 
 # define obstack_blank(h, length)					      \
   ((h)->temp.i = (length),						      \
-   ((obstack_room (h) < (h)->temp.i)					      \
-   ? (_obstack_newchunk ((h), (h)->temp.i), 0) : 0),			      \
+   _obstack_newchunk ((h), (h)->temp.i),			      \
    obstack_blank_fast (h, (h)->temp.i))
 
 # define obstack_alloc(h, length)					      \

--- a/projects/git-2.46.0/compat/obstack.c
+++ b/projects/git-2.46.0/compat/obstack.c
@@ -142,27 +142,12 @@ _obstack_begin (struct obstack *h,
 
   if (alignment == 0)
     alignment = DEFAULT_ALIGNMENT;
-  if (size == 0)
-    /* Default size is what GNU malloc can fit in a 4096-byte block.  */
-    {
-      /* 12 is sizeof (mhead) and 4 is EXTRA from GNU malloc.
-	 Use the values for range checking, because if range checking is off,
-	 the extra bytes won't be missed terribly, but if range checking is on
-	 and we used a larger request, a whole extra 4096 bytes would be
-	 allocated.
-
-	 These number are irrelevant to the new GNU malloc.  I suspect it is
-	 less sensitive to the size of the request.  */
-      int extra = ((((12 + DEFAULT_ROUNDING - 1) & ~(DEFAULT_ROUNDING - 1))
-		    + 4 + DEFAULT_ROUNDING - 1)
-		   & ~(DEFAULT_ROUNDING - 1));
-      size = 4096 - extra;
-    }
 
   h->chunkfun.plain = chunkfun;
   h->freefun.plain = freefun;
-  h->chunk_size = size;
   h->alignment_mask = alignment - 1;
+  size = sizeof (struct _obstack_chunk) + h->alignment_mask;
+  h->chunk_size = size;
   h->use_extra_arg = 0;
 
   chunk = h->chunk = CALL_CHUNKFUN (h, h -> chunk_size);
@@ -189,28 +174,13 @@ _obstack_begin_1 (struct obstack *h, int size, int alignment,
 
   if (alignment == 0)
     alignment = DEFAULT_ALIGNMENT;
-  if (size == 0)
-    /* Default size is what GNU malloc can fit in a 4096-byte block.  */
-    {
-      /* 12 is sizeof (mhead) and 4 is EXTRA from GNU malloc.
-	 Use the values for range checking, because if range checking is off,
-	 the extra bytes won't be missed terribly, but if range checking is on
-	 and we used a larger request, a whole extra 4096 bytes would be
-	 allocated.
-
-	 These number are irrelevant to the new GNU malloc.  I suspect it is
-	 less sensitive to the size of the request.  */
-      int extra = ((((12 + DEFAULT_ROUNDING - 1) & ~(DEFAULT_ROUNDING - 1))
-		    + 4 + DEFAULT_ROUNDING - 1)
-		   & ~(DEFAULT_ROUNDING - 1));
-      size = 4096 - extra;
-    }
 
   h->chunkfun.extra = (struct _obstack_chunk * (*)(void *,long)) chunkfun;
   h->freefun.extra = (void (*) (void *, struct _obstack_chunk *)) freefun;
 
-  h->chunk_size = size;
   h->alignment_mask = alignment - 1;
+  size = sizeof (struct _obstack_chunk) + h->alignment_mask;
+  h->chunk_size = size;
   h->extra_arg = arg;
   h->use_extra_arg = 1;
 
@@ -246,9 +216,11 @@ _obstack_newchunk (struct obstack *h, int length)
   char *object_base;
 
   /* Compute size for new chunk.  */
-  new_size = (obj_size + length) + (obj_size >> 3) + h->alignment_mask + 100;
-  if (new_size < h->chunk_size)
-    new_size = h->chunk_size;
+  if (obj_size)
+    new_size = 2 * (obj_size + length);
+  else
+    new_size = length;
+  new_size += sizeof (struct _obstack_chunk) + h->alignment_mask;
 
   /* Allocate and initialize the new chunk.  */
   new_chunk = CALL_CHUNKFUN (h, new_size);

--- a/projects/git-2.46.0/compat/obstack.h
+++ b/projects/git-2.46.0/compat/obstack.h
@@ -356,8 +356,7 @@ __extension__								\
 __extension__								\
 ({ struct obstack *__o = (OBSTACK);					\
    int __len = (length);						\
-   if (__o->chunk_limit - __o->next_free < __len)			\
-     _obstack_newchunk (__o, __len);					\
+   _obstack_newchunk (__o, __len);					\
    obstack_blank_fast (__o, __len);					\
    (void) 0; })
 
@@ -467,8 +466,7 @@ __extension__								\
 
 # define obstack_blank(h,length)					\
 ( (h)->temp.tempint = (length),						\
-  (((h)->chunk_limit - (h)->next_free < (h)->temp.tempint)		\
-   ? (_obstack_newchunk ((h), (h)->temp.tempint), 0) : 0),		\
+  _obstack_newchunk ((h), (h)->temp.tempint),		\
   obstack_blank_fast (h, (h)->temp.tempint))
 
 # define obstack_alloc(h,length)					\

--- a/projects/grep-3.11/lib/obstack.c
+++ b/projects/grep-3.11/lib/obstack.c
@@ -112,25 +112,11 @@ _obstack_begin_worker (struct obstack *h,
 
   if (alignment == 0)
     alignment = DEFAULT_ALIGNMENT;
-  if (size == 0)
-    /* Default size is what GNU malloc can fit in a 4096-byte block.  */
-    {
-      /* 12 is sizeof (mhead) and 4 is EXTRA from GNU malloc.
-         Use the values for range checking, because if range checking is off,
-         the extra bytes won't be missed terribly, but if range checking is on
-         and we used a larger request, a whole extra 4096 bytes would be
-         allocated.
 
-         These number are irrelevant to the new GNU malloc.  I suspect it is
-         less sensitive to the size of the request.  */
-      int extra = ((((12 + DEFAULT_ROUNDING - 1) & ~(DEFAULT_ROUNDING - 1))
-                    + 4 + DEFAULT_ROUNDING - 1)
-                   & ~(DEFAULT_ROUNDING - 1));
-      size = 4096 - extra;
-    }
-
-  h->chunk_size = size;
   h->alignment_mask = alignment - 1;
+
+  size = sizeof (struct _obstack_chunk) + h->alignment_mask;
+  h->chunk_size = size;
 
   chunk = h->chunk = call_chunkfun (h, h->chunk_size);
   if (!chunk)
@@ -186,19 +172,19 @@ _obstack_newchunk (struct obstack *h, _OBSTACK_SIZE_T length)
   char *object_base;
 
   /* Compute size for new chunk.  */
-  size_t sum1 = obj_size + length;
-  size_t sum2 = sum1 + h->alignment_mask;
-  size_t new_size = sum2 + (obj_size >> 3) + 100;
-  if (new_size < sum2)
-    new_size = sum2;
-  if (new_size < h->chunk_size)
-    new_size = h->chunk_size;
+  size_t new_size;
+  if (obj_size)
+    new_size = 2 * (obj_size + length);
+  else
+    new_size = length;
+  new_size += sizeof (struct _obstack_chunk) + h->alignment_mask;
 
   /* Allocate and initialize the new chunk.  */
-  if (obj_size <= sum1 && sum1 <= sum2)
+  if (new_size >= length && new_size >= obj_size)
     new_chunk = call_chunkfun (h, new_size);
   if (!new_chunk)
     (*obstack_alloc_failed_handler)();
+
   h->chunk = new_chunk;
   new_chunk->prev = old_chunk;
   new_chunk->limit = h->chunk_limit = (char *) new_chunk + new_size;

--- a/projects/grep-3.11/lib/obstack.h
+++ b/projects/grep-3.11/lib/obstack.h
@@ -397,8 +397,7 @@ extern int obstack_exit_failure;
   __extension__								      \
     ({ struct obstack *__o = (OBSTACK);					      \
        _OBSTACK_SIZE_T __len = (length);				      \
-       if (obstack_room (__o) < __len)					      \
-         _obstack_newchunk (__o, __len);				      \
+       _obstack_newchunk (__o, __len);				      \
        obstack_blank_fast (__o, __len); })
 
 # define obstack_alloc(OBSTACK, length)					      \
@@ -513,8 +512,7 @@ extern int obstack_exit_failure;
 
 # define obstack_blank(h, length)					      \
   ((h)->temp.i = (length),						      \
-   ((obstack_room (h) < (h)->temp.i)					      \
-   ? (_obstack_newchunk ((h), (h)->temp.i), 0) : 0),			      \
+   _obstack_newchunk ((h), (h)->temp.i),			      \
    obstack_blank_fast (h, (h)->temp.i))
 
 # define obstack_alloc(h, length)					      \

--- a/projects/m4-1.4.19/lib/obstack.c
+++ b/projects/m4-1.4.19/lib/obstack.c
@@ -113,25 +113,11 @@ _obstack_begin_worker (struct obstack *h,
 
   if (alignment == 0)
     alignment = DEFAULT_ALIGNMENT;
-  if (size == 0)
-    /* Default size is what GNU malloc can fit in a 4096-byte block.  */
-    {
-      /* 12 is sizeof (mhead) and 4 is EXTRA from GNU malloc.
-         Use the values for range checking, because if range checking is off,
-         the extra bytes won't be missed terribly, but if range checking is on
-         and we used a larger request, a whole extra 4096 bytes would be
-         allocated.
 
-         These number are irrelevant to the new GNU malloc.  I suspect it is
-         less sensitive to the size of the request.  */
-      int extra = ((((12 + DEFAULT_ROUNDING - 1) & ~(DEFAULT_ROUNDING - 1))
-                    + 4 + DEFAULT_ROUNDING - 1)
-                   & ~(DEFAULT_ROUNDING - 1));
-      size = 4096 - extra;
-    }
-
-  h->chunk_size = size;
   h->alignment_mask = alignment - 1;
+
+  size = sizeof (struct _obstack_chunk) + h->alignment_mask;
+  h->chunk_size = size;
 
   chunk = h->chunk = call_chunkfun (h, h->chunk_size);
   if (!chunk)
@@ -187,19 +173,19 @@ _obstack_newchunk (struct obstack *h, _OBSTACK_SIZE_T length)
   char *object_base;
 
   /* Compute size for new chunk.  */
-  size_t sum1 = obj_size + length;
-  size_t sum2 = sum1 + h->alignment_mask;
-  size_t new_size = sum2 + (obj_size >> 3) + 100;
-  if (new_size < sum2)
-    new_size = sum2;
-  if (new_size < h->chunk_size)
-    new_size = h->chunk_size;
+  size_t new_size;
+  if (obj_size)
+    new_size = 2 * (obj_size + length);
+  else
+    new_size = length;
+  new_size += sizeof (struct _obstack_chunk) + h->alignment_mask;
 
   /* Allocate and initialize the new chunk.  */
-  if (obj_size <= sum1 && sum1 <= sum2)
+  if (new_size >= length && new_size >= obj_size)
     new_chunk = call_chunkfun (h, new_size);
   if (!new_chunk)
     (*obstack_alloc_failed_handler)();
+
   h->chunk = new_chunk;
   new_chunk->prev = old_chunk;
   new_chunk->limit = h->chunk_limit = (char *) new_chunk + new_size;

--- a/projects/m4-1.4.19/lib/obstack.h
+++ b/projects/m4-1.4.19/lib/obstack.h
@@ -393,8 +393,7 @@ extern int obstack_exit_failure;
   __extension__								      \
     ({ struct obstack *__o = (OBSTACK);					      \
        _OBSTACK_SIZE_T __len = (length);				      \
-       if (obstack_room (__o) < __len)					      \
-         _obstack_newchunk (__o, __len);				      \
+       _obstack_newchunk (__o, __len);				      \
        obstack_blank_fast (__o, __len); })
 
 # define obstack_alloc(OBSTACK, length)					      \
@@ -509,8 +508,7 @@ extern int obstack_exit_failure;
 
 # define obstack_blank(h, length)					      \
   ((h)->temp.i = (length),						      \
-   ((obstack_room (h) < (h)->temp.i)					      \
-   ? (_obstack_newchunk ((h), (h)->temp.i), 0) : 0),			      \
+   _obstack_newchunk ((h), (h)->temp.i),			      \
    obstack_blank_fast (h, (h)->temp.i))
 
 # define obstack_alloc(h, length)					      \

--- a/projects/sed-4.9/lib/obstack.c
+++ b/projects/sed-4.9/lib/obstack.c
@@ -112,25 +112,11 @@ _obstack_begin_worker (struct obstack *h,
 
   if (alignment == 0)
     alignment = DEFAULT_ALIGNMENT;
-  if (size == 0)
-    /* Default size is what GNU malloc can fit in a 4096-byte block.  */
-    {
-      /* 12 is sizeof (mhead) and 4 is EXTRA from GNU malloc.
-         Use the values for range checking, because if range checking is off,
-         the extra bytes won't be missed terribly, but if range checking is on
-         and we used a larger request, a whole extra 4096 bytes would be
-         allocated.
 
-         These number are irrelevant to the new GNU malloc.  I suspect it is
-         less sensitive to the size of the request.  */
-      int extra = ((((12 + DEFAULT_ROUNDING - 1) & ~(DEFAULT_ROUNDING - 1))
-                    + 4 + DEFAULT_ROUNDING - 1)
-                   & ~(DEFAULT_ROUNDING - 1));
-      size = 4096 - extra;
-    }
-
-  h->chunk_size = size;
   h->alignment_mask = alignment - 1;
+
+  size = sizeof (struct _obstack_chunk) + h->alignment_mask;
+  h->chunk_size = size;
 
   chunk = h->chunk = call_chunkfun (h, h->chunk_size);
   if (!chunk)
@@ -186,19 +172,19 @@ _obstack_newchunk (struct obstack *h, _OBSTACK_SIZE_T length)
   char *object_base;
 
   /* Compute size for new chunk.  */
-  size_t sum1 = obj_size + length;
-  size_t sum2 = sum1 + h->alignment_mask;
-  size_t new_size = sum2 + (obj_size >> 3) + 100;
-  if (new_size < sum2)
-    new_size = sum2;
-  if (new_size < h->chunk_size)
-    new_size = h->chunk_size;
+  size_t new_size;
+  if (obj_size)
+    new_size = 2 * (obj_size + length);
+  else
+    new_size = length;
+  new_size += sizeof (struct _obstack_chunk) + h->alignment_mask;
 
   /* Allocate and initialize the new chunk.  */
-  if (obj_size <= sum1 && sum1 <= sum2)
+  if (new_size >= length && new_size >= obj_size)
     new_chunk = call_chunkfun (h, new_size);
   if (!new_chunk)
     (*obstack_alloc_failed_handler)();
+
   h->chunk = new_chunk;
   new_chunk->prev = old_chunk;
   new_chunk->limit = h->chunk_limit = (char *) new_chunk + new_size;

--- a/projects/sed-4.9/lib/obstack.h
+++ b/projects/sed-4.9/lib/obstack.h
@@ -392,8 +392,7 @@ extern int obstack_exit_failure;
   __extension__								      \
     ({ struct obstack *__o = (OBSTACK);					      \
        _OBSTACK_SIZE_T __len = (length);				      \
-       if (obstack_room (__o) < __len)					      \
-         _obstack_newchunk (__o, __len);				      \
+       _obstack_newchunk (__o, __len);				      \
        obstack_blank_fast (__o, __len); })
 
 # define obstack_alloc(OBSTACK, length)					      \
@@ -508,8 +507,7 @@ extern int obstack_exit_failure;
 
 # define obstack_blank(h, length)					      \
   ((h)->temp.i = (length),						      \
-   ((obstack_room (h) < (h)->temp.i)					      \
-   ? (_obstack_newchunk ((h), (h)->temp.i), 0) : 0),			      \
+   _obstack_newchunk ((h), (h)->temp.i),			      \
    obstack_blank_fast (h, (h)->temp.i))
 
 # define obstack_alloc(h, length)					      \

--- a/projects/tar-1.35/gnu/obstack.c
+++ b/projects/tar-1.35/gnu/obstack.c
@@ -112,25 +112,11 @@ _obstack_begin_worker (struct obstack *h,
 
   if (alignment == 0)
     alignment = DEFAULT_ALIGNMENT;
-  if (size == 0)
-    /* Default size is what GNU malloc can fit in a 4096-byte block.  */
-    {
-      /* 12 is sizeof (mhead) and 4 is EXTRA from GNU malloc.
-         Use the values for range checking, because if range checking is off,
-         the extra bytes won't be missed terribly, but if range checking is on
-         and we used a larger request, a whole extra 4096 bytes would be
-         allocated.
 
-         These number are irrelevant to the new GNU malloc.  I suspect it is
-         less sensitive to the size of the request.  */
-      int extra = ((((12 + DEFAULT_ROUNDING - 1) & ~(DEFAULT_ROUNDING - 1))
-                    + 4 + DEFAULT_ROUNDING - 1)
-                   & ~(DEFAULT_ROUNDING - 1));
-      size = 4096 - extra;
-    }
-
-  h->chunk_size = size;
   h->alignment_mask = alignment - 1;
+
+  size = sizeof (struct _obstack_chunk) + h->alignment_mask;
+  h->chunk_size = size;
 
   chunk = h->chunk = call_chunkfun (h, h->chunk_size);
   if (!chunk)
@@ -186,19 +172,19 @@ _obstack_newchunk (struct obstack *h, _OBSTACK_SIZE_T length)
   char *object_base;
 
   /* Compute size for new chunk.  */
-  size_t sum1 = obj_size + length;
-  size_t sum2 = sum1 + h->alignment_mask;
-  size_t new_size = sum2 + (obj_size >> 3) + 100;
-  if (new_size < sum2)
-    new_size = sum2;
-  if (new_size < h->chunk_size)
-    new_size = h->chunk_size;
+  size_t new_size;
+  if (obj_size)
+    new_size = 2 * (obj_size + length);
+  else
+    new_size = length;
+  new_size += sizeof (struct _obstack_chunk) + h->alignment_mask;
 
   /* Allocate and initialize the new chunk.  */
-  if (obj_size <= sum1 && sum1 <= sum2)
+  if (new_size >= length && new_size >= obj_size)
     new_chunk = call_chunkfun (h, new_size);
   if (!new_chunk)
     (*obstack_alloc_failed_handler)();
+
   h->chunk = new_chunk;
   new_chunk->prev = old_chunk;
   new_chunk->limit = h->chunk_limit = (char *) new_chunk + new_size;

--- a/projects/tar-1.35/gnu/obstack.h
+++ b/projects/tar-1.35/gnu/obstack.h
@@ -397,8 +397,7 @@ extern int obstack_exit_failure;
   __extension__								      \
     ({ struct obstack *__o = (OBSTACK);					      \
        _OBSTACK_SIZE_T __len = (length);				      \
-       if (obstack_room (__o) < __len)					      \
-         _obstack_newchunk (__o, __len);				      \
+       _obstack_newchunk (__o, __len);				      \
        obstack_blank_fast (__o, __len); })
 
 # define obstack_alloc(OBSTACK, length)					      \
@@ -513,8 +512,7 @@ extern int obstack_exit_failure;
 
 # define obstack_blank(h, length)					      \
   ((h)->temp.i = (length),						      \
-   ((obstack_room (h) < (h)->temp.i)					      \
-   ? (_obstack_newchunk ((h), (h)->temp.i), 0) : 0),			      \
+   _obstack_newchunk ((h), (h)->temp.i),			      \
    obstack_blank_fast (h, (h)->temp.i))
 
 # define obstack_alloc(h, length)					      \

--- a/projects/texinfo-7.1/tp/Texinfo/XS/gnulib/lib/obstack.c
+++ b/projects/texinfo-7.1/tp/Texinfo/XS/gnulib/lib/obstack.c
@@ -112,25 +112,11 @@ _obstack_begin_worker (struct obstack *h,
 
   if (alignment == 0)
     alignment = DEFAULT_ALIGNMENT;
-  if (size == 0)
-    /* Default size is what GNU malloc can fit in a 4096-byte block.  */
-    {
-      /* 12 is sizeof (mhead) and 4 is EXTRA from GNU malloc.
-         Use the values for range checking, because if range checking is off,
-         the extra bytes won't be missed terribly, but if range checking is on
-         and we used a larger request, a whole extra 4096 bytes would be
-         allocated.
 
-         These number are irrelevant to the new GNU malloc.  I suspect it is
-         less sensitive to the size of the request.  */
-      int extra = ((((12 + DEFAULT_ROUNDING - 1) & ~(DEFAULT_ROUNDING - 1))
-                    + 4 + DEFAULT_ROUNDING - 1)
-                   & ~(DEFAULT_ROUNDING - 1));
-      size = 4096 - extra;
-    }
-
-  h->chunk_size = size;
   h->alignment_mask = alignment - 1;
+
+  size = sizeof (struct _obstack_chunk) + h->alignment_mask;
+  h->chunk_size = size;
 
   chunk = h->chunk = call_chunkfun (h, h->chunk_size);
   if (!chunk)
@@ -186,19 +172,19 @@ _obstack_newchunk (struct obstack *h, _OBSTACK_SIZE_T length)
   char *object_base;
 
   /* Compute size for new chunk.  */
-  size_t sum1 = obj_size + length;
-  size_t sum2 = sum1 + h->alignment_mask;
-  size_t new_size = sum2 + (obj_size >> 3) + 100;
-  if (new_size < sum2)
-    new_size = sum2;
-  if (new_size < h->chunk_size)
-    new_size = h->chunk_size;
+  size_t new_size;
+  if (obj_size)
+    new_size = 2 * (obj_size + length);
+  else
+    new_size = length;
+  new_size += sizeof (struct _obstack_chunk) + h->alignment_mask;
 
   /* Allocate and initialize the new chunk.  */
-  if (obj_size <= sum1 && sum1 <= sum2)
+  if (new_size >= length && new_size >= obj_size)
     new_chunk = call_chunkfun (h, new_size);
   if (!new_chunk)
     (*obstack_alloc_failed_handler)();
+
   h->chunk = new_chunk;
   new_chunk->prev = old_chunk;
   new_chunk->limit = h->chunk_limit = (char *) new_chunk + new_size;

--- a/projects/texinfo-7.1/tp/Texinfo/XS/gnulib/lib/obstack.h
+++ b/projects/texinfo-7.1/tp/Texinfo/XS/gnulib/lib/obstack.h
@@ -397,8 +397,7 @@ extern int obstack_exit_failure;
   __extension__								      \
     ({ struct obstack *__o = (OBSTACK);					      \
        _OBSTACK_SIZE_T __len = (length);				      \
-       if (obstack_room (__o) < __len)					      \
-         _obstack_newchunk (__o, __len);				      \
+       _obstack_newchunk (__o, __len);				      \
        obstack_blank_fast (__o, __len); })
 
 # define obstack_alloc(OBSTACK, length)					      \
@@ -513,8 +512,7 @@ extern int obstack_exit_failure;
 
 # define obstack_blank(h, length)					      \
   ((h)->temp.i = (length),						      \
-   ((obstack_room (h) < (h)->temp.i)					      \
-   ? (_obstack_newchunk ((h), (h)->temp.i), 0) : 0),			      \
+   _obstack_newchunk ((h), (h)->temp.i),			      \
    obstack_blank_fast (h, (h)->temp.i))
 
 # define obstack_alloc(h, length)					      \

--- a/projects/user-glibc-2.40/malloc/obstack.c
+++ b/projects/user-glibc-2.40/malloc/obstack.c
@@ -150,27 +150,13 @@ _obstack_begin (struct obstack *h,
 
   if (alignment == 0)
     alignment = DEFAULT_ALIGNMENT;
-  if (size == 0)
-    /* Default size is what GNU malloc can fit in a 4096-byte block.  */
-    {
-      /* 12 is sizeof (mhead) and 4 is EXTRA from GNU malloc.
-	 Use the values for range checking, because if range checking is off,
-	 the extra bytes won't be missed terribly, but if range checking is on
-	 and we used a larger request, a whole extra 4096 bytes would be
-	 allocated.
 
-	 These number are irrelevant to the new GNU malloc.  I suspect it is
-	 less sensitive to the size of the request.  */
-      int extra = ((((12 + DEFAULT_ROUNDING - 1) & ~(DEFAULT_ROUNDING - 1))
-		    + 4 + DEFAULT_ROUNDING - 1)
-		   & ~(DEFAULT_ROUNDING - 1));
-      size = 4096 - extra;
-    }
 
   h->chunkfun = (struct _obstack_chunk * (*) (void *, long)) chunkfun;
   h->freefun = (void (*) (void *, struct _obstack_chunk *)) freefun;
-  h->chunk_size = size;
   h->alignment_mask = alignment - 1;
+  size = sizeof (struct _obstack_chunk) + h->alignment_mask;
+  h->chunk_size = size;
   h->use_extra_arg = 0;
 
   chunk = h->chunk = CALL_CHUNKFUN (h, h->chunk_size);
@@ -197,27 +183,12 @@ _obstack_begin_1 (struct obstack *h, int size, int alignment,
 
   if (alignment == 0)
     alignment = DEFAULT_ALIGNMENT;
-  if (size == 0)
-    /* Default size is what GNU malloc can fit in a 4096-byte block.  */
-    {
-      /* 12 is sizeof (mhead) and 4 is EXTRA from GNU malloc.
-	 Use the values for range checking, because if range checking is off,
-	 the extra bytes won't be missed terribly, but if range checking is on
-	 and we used a larger request, a whole extra 4096 bytes would be
-	 allocated.
-
-	 These number are irrelevant to the new GNU malloc.  I suspect it is
-	 less sensitive to the size of the request.  */
-      int extra = ((((12 + DEFAULT_ROUNDING - 1) & ~(DEFAULT_ROUNDING - 1))
-		    + 4 + DEFAULT_ROUNDING - 1)
-		   & ~(DEFAULT_ROUNDING - 1));
-      size = 4096 - extra;
-    }
 
   h->chunkfun = (struct _obstack_chunk * (*)(void *,long)) chunkfun;
   h->freefun = (void (*) (void *, struct _obstack_chunk *)) freefun;
-  h->chunk_size = size;
   h->alignment_mask = alignment - 1;
+  size = sizeof (struct _obstack_chunk) + h->alignment_mask;
+  h->chunk_size = size;
   h->extra_arg = arg;
   h->use_extra_arg = 1;
 
@@ -253,9 +224,11 @@ _obstack_newchunk (struct obstack *h, int length)
   char *object_base;
 
   /* Compute size for new chunk.  */
-  new_size = (obj_size + length) + (obj_size >> 3) + h->alignment_mask + 100;
-  if (new_size < h->chunk_size)
-    new_size = h->chunk_size;
+  if (obj_size)
+    new_size = 2 * (obj_size + length);
+  else
+    new_size = length;
+  new_size += sizeof (struct _obstack_chunk) + h->alignment_mask;
 
   /* Allocate and initialize the new chunk.  */
   new_chunk = CALL_CHUNKFUN (h, new_size);

--- a/projects/user-glibc-2.40/malloc/obstack.h
+++ b/projects/user-glibc-2.40/malloc/obstack.h
@@ -365,8 +365,7 @@ extern int obstack_exit_failure;
   __extension__								      \
     ({ struct obstack *__o = (OBSTACK);					      \
        int __len = (length);						      \
-       if (__o->chunk_limit - __o->next_free < __len)			      \
-	 _obstack_newchunk (__o, __len);				      \
+	   _obstack_newchunk (__o, __len);				      \
        obstack_blank_fast (__o, __len);					      \
        (void) 0; })
 
@@ -476,8 +475,7 @@ extern int obstack_exit_failure;
 
 # define obstack_blank(h, length)					      \
   ((h)->temp.tempint = (length),					      \
-   (((h)->chunk_limit - (h)->next_free < (h)->temp.tempint)		      \
-   ? (_obstack_newchunk ((h), (h)->temp.tempint), 0) : 0),		      \
+   _obstack_newchunk ((h), (h)->temp.tempint),		      \
    obstack_blank_fast (h, (h)->temp.tempint))
 
 # define obstack_alloc(h, length)					      \


### PR DESCRIPTION
This is better for memory safety because it will disallow out of bound writes between objects allocated via obstack. Before, they were only disallowed if the objects ended up in different chunks. If they were in the same chunk, they would be viewed as the same object by the capability system.