### PR TITLE
typedef EncodedJSValue to void* instead of uint64_t so we don't drop

### DIFF
--- a/projects/webkitgtk-2.44.3/Source/JavaScriptCore/interpreter/CalleeBits.h
+++ b/projects/webkitgtk-2.44.3/Source/JavaScriptCore/interpreter/CalleeBits.h
@@ -82,19 +82,19 @@ public:
 #elif USE(JSVALUE64)
     static EncodedJSValue encodeNullCallee()
     {
-        return reinterpret_cast<EncodedJSValue>(nullptr);
+        return static_cast<EncodedJSValue>(nullptr);
     }
 
     static EncodedJSValue encodeJSCallee(const JSCell* cell)
     {
         if (!cell)
             return encodeNullCallee();
-        return reinterpret_cast<EncodedJSValue>(cell);
+        return static_cast<EncodedJSValue>(const_cast<JSCell*>(cell));
     }
 
     static EncodedJSValue encodeBoxedNativeCallee(void* boxedCallee)
     {
-        return reinterpret_cast<EncodedJSValue>(boxedCallee);
+        return static_cast<EncodedJSValue>(boxedCallee);
     }
 #else
 #error "Unsupported configuration"

--- a/projects/webkitgtk-2.44.3/Source/JavaScriptCore/llint/LLIntThunks.h
+++ b/projects/webkitgtk-2.44.3/Source/JavaScriptCore/llint/LLIntThunks.h
@@ -33,7 +33,7 @@
 namespace JSC {
 
 struct ProtoCallFrame;
-typedef int64_t EncodedJSValue;
+typedef void* EncodedJSValue;
 
 extern "C" {
     EncodedJSValue vmEntryToJavaScript(void*, VM*, ProtoCallFrame*);

--- a/projects/webkitgtk-2.44.3/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
+++ b/projects/webkitgtk-2.44.3/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
@@ -1135,7 +1135,7 @@ ALWAYS_INLINE JSValue fastIndexOf(JSGlobalObject* globalObject, VM& vm, JSArray*
 
         if (direction == IndexOfDirection::Forward) {
             if (searchElement.isObject()) {
-                auto* result = bitwise_cast<const WriteBarrier<Unknown>*>(WTF::find64(bitwise_cast<const uint64_t*>(data + index), JSValue::encode(searchElement), length - index));
+                auto* result = reinterpret_cast<const WriteBarrier<Unknown>*>(WTF::genericFind64<JSValue>(reinterpret_cast<const JSValue*>(data + index), searchElement, length - index));
                 if (result)
                     return jsNumber(result - data);
                 return jsNumber(-1);
@@ -1604,7 +1604,7 @@ JSC_DEFINE_HOST_FUNCTION(arrayProtoPrivateFuncFromFast, (JSGlobalObject* globalO
         }
     } else if (sourceType == ArrayWithInt32) {
         auto* buffer = butterfly->contiguous().data();
-        if (UNLIKELY(WTF::find64(bitwise_cast<const uint64_t*>(buffer), JSValue::encode(JSValue()), resultSize)))
+        if (UNLIKELY(WTF::genericFind64<JSValue>(reinterpret_cast<JSValue*>(buffer), JSValue(), resultSize)))
             resultType = ArrayWithContiguous;
     } else if (sourceType == ArrayWithUndecided && resultSize)
         resultType = ArrayWithContiguous;

--- a/projects/webkitgtk-2.44.3/Source/JavaScriptCore/runtime/HashMapImplInlines.h
+++ b/projects/webkitgtk-2.44.3/Source/JavaScriptCore/runtime/HashMapImplInlines.h
@@ -68,8 +68,9 @@ ALWAYS_INLINE JSValue normalizeMapKey(JSValue key)
     return key;
 }
 
-ALWAYS_INLINE uint32_t wangsInt64Hash(uint64_t key)
+ALWAYS_INLINE uint32_t wangsInt64Hash(EncodedJSValue encodedKey)
 {
+    uint64_t key = bitwise_cast<uint64_t>(encodedKey);
     key += ~(key << 32);
     key ^= (key >> 22);
     key += ~(key << 13);
@@ -133,7 +134,7 @@ ALWAYS_INLINE std::optional<uint32_t> concurrentJSMapHash(JSValue key)
     if (key.isHeapBigInt())
         return key.asHeapBigInt()->concurrentHash();
 
-    uint64_t rawValue = JSValue::encode(key);
+    EncodedJSValue rawValue = JSValue::encode(key);
     return wangsInt64Hash(rawValue);
 }
 

--- a/projects/webkitgtk-2.44.3/Source/JavaScriptCore/runtime/JSArray.cpp
+++ b/projects/webkitgtk-2.44.3/Source/JavaScriptCore/runtime/JSArray.cpp
@@ -1109,7 +1109,7 @@ bool JSArray::unshiftCountWithAnyIndexingType(JSGlobalObject* globalObject, unsi
         // through shifting and then realize we should have been in ArrayStorage mode.
         if (moveCount) {
             if (UNLIKELY(holesMustForwardToPrototype())) {
-                if (UNLIKELY(WTF::find64(bitwise_cast<const uint64_t*>(butterfly->contiguous().data() + startIndex), JSValue::encode(JSValue()), moveCount)))
+                if (UNLIKELY(WTF::genericFind64<JSValue>(reinterpret_cast<JSValue*>(butterfly->contiguous().data() + startIndex), JSValue(), moveCount)))
                     RELEASE_AND_RETURN(scope, unshiftCountWithArrayStorage(globalObject, startIndex, count, ensureArrayStorage(vm)));
             }
 

--- a/projects/webkitgtk-2.44.3/Source/JavaScriptCore/runtime/JSCJSValue.h
+++ b/projects/webkitgtk-2.44.3/Source/JavaScriptCore/runtime/JSCJSValue.h
@@ -86,7 +86,7 @@ enum PreferredPrimitiveType : uint8_t { NoPreference, PreferNumber, PreferString
 
 struct CallData;
 
-typedef int64_t EncodedJSValue;
+typedef void* EncodedJSValue;
 
 inline void updateEncodedJSValueConcurrent(EncodedJSValue&, EncodedJSValue);
 inline void clearEncodedJSValueConcurrent(EncodedJSValue&);
@@ -97,6 +97,7 @@ union EncodedValueDescriptor {
     double asDouble;
 #elif USE(JSVALUE64)
     JSCell* ptr;
+    void* encodedAsPtr;
 #endif
         
 #if CPU(BIG_ENDIAN)
@@ -546,7 +547,7 @@ private:
     EncodedValueDescriptor u;
 };
 
-typedef IntHash<EncodedJSValue> EncodedJSValueHash;
+typedef PtrHash<EncodedJSValue> EncodedJSValueHash;
 
 #if USE(JSVALUE32_64)
 struct EncodedJSValueHashTraits : HashTraits<EncodedJSValue> {

--- a/projects/webkitgtk-2.44.3/Source/JavaScriptCore/runtime/JSCJSValueInlines.h
+++ b/projects/webkitgtk-2.44.3/Source/JavaScriptCore/runtime/JSCJSValueInlines.h
@@ -255,13 +255,13 @@ inline JSValue::JSValue(double d)
 
 inline EncodedJSValue JSValue::encode(JSValue value)
 {
-    return value.u.asInt64;
+    return value.u.encodedAsPtr;
 }
 
 inline JSValue JSValue::decode(EncodedJSValue encodedJSValue)
 {
     JSValue v;
-    v.u.asInt64 = encodedJSValue;
+    v.u.encodedAsPtr = encodedJSValue;
     return v;
 }
 

--- a/projects/webkitgtk-2.44.3/Source/JavaScriptCore/tools/Integrity.cpp
+++ b/projects/webkitgtk-2.44.3/Source/JavaScriptCore/tools/Integrity.cpp
@@ -284,7 +284,7 @@ bool Analyzer::analyzeCell(JSCell* cell, Analyzer::Action action)
     if (!cell)
         return cell;
 
-    JSValue value = JSValue::decode(static_cast<EncodedJSValue>(bitwise_cast<uintptr_t>(cell)));
+    JSValue value = JSValue(cell);
     AUDIT_VERIFY(value.isCell(), "Invalid cell address: cell %p", cell);
 
     VM& vm = cell->vm();

--- a/projects/webkitgtk-2.44.3/Source/WTF/wtf/text/StringCommon.h
+++ b/projects/webkitgtk-2.44.3/Source/WTF/wtf/text/StringCommon.h
@@ -653,6 +653,16 @@ ALWAYS_INLINE const uint64_t* find64(const uint64_t* pointer, uint64_t character
 }
 #endif
 
+template <typename T>
+ALWAYS_INLINE const T* genericFind64(const T* pointer, T character, size_t length)
+{
+    for (size_t index = 0; index < length; ++index) {
+        if (pointer[index] == character)
+            return pointer + index;
+    }
+    return nullptr;
+}
+
 #if CPU(ARM64)
 WTF_EXPORT_PRIVATE const float* findFloatAlignedImpl(const float* pointer, float target, size_t length);
 


### PR DESCRIPTION
capabilities when passing an EncodedJSValue around.