### PR TITLE
Kill narrow opcodes by just making them crash() if ever invoked.

### DIFF
--- a/projects/webkitgtk-2.44.3/Source/JavaScriptCore/bytecode/BytecodeList.rb
+++ b/projects/webkitgtk-2.44.3/Source/JavaScriptCore/bytecode/BytecodeList.rb
@@ -1407,28 +1407,10 @@ op :fuzzer_return_early_from_loop_hint
 op :loop_osr_entry_gate
 op :llint_get_host_call_return_value
 op :llint_handle_uncaught_exception
-op :op_call_return_location
-op :op_call_ignore_result_return_location
-op :op_construct_return_location
-op :op_call_varargs_return_location
-op :op_construct_varargs_return_location
-op :op_get_by_id_return_location
-op :op_get_by_val_return_location
-op :op_put_by_id_return_location
-op :op_put_by_val_return_location
-op :op_iterator_open_return_location
-op :op_iterator_next_return_location
 op :op_call_direct_eval_slow_return_location
 op :wasm_function_prologue
 op :wasm_function_prologue_simd
 
-op :js_trampoline_op_call
-op :js_trampoline_op_call_ignore_result
-op :js_trampoline_op_construct
-op :js_trampoline_op_call_varargs
-op :js_trampoline_op_construct_varargs
-op :js_trampoline_op_iterator_next
-op :js_trampoline_op_iterator_open
 op :js_trampoline_op_call_direct_eval_slow
 op :js_trampoline_llint_function_for_call_arity_check_untag
 op :js_trampoline_llint_function_for_call_arity_check_tag
@@ -1458,13 +1440,6 @@ op :llint_cloop_did_return_from_js_8
 op :llint_cloop_did_return_from_js_9
 op :llint_cloop_did_return_from_js_10
 op :llint_cloop_did_return_from_js_11
-op :llint_cloop_did_return_from_js_12
-op :llint_cloop_did_return_from_js_13
-op :llint_cloop_did_return_from_js_14
-op :llint_cloop_did_return_from_js_15
-op :llint_cloop_did_return_from_js_16
-op :llint_cloop_did_return_from_js_17
-op :llint_cloop_did_return_from_js_18
 
 end_section :CLoopReturnHelpers
 
@@ -1900,3 +1875,4 @@ op :extern_convert_any,
     }
 
 end_section :Wasm
+

--- a/projects/webkitgtk-2.44.3/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
+++ b/projects/webkitgtk-2.44.3/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
@@ -5483,7 +5483,7 @@ ALWAYS_INLINE void rewriteOp(BytecodeGenerator& generator, TupleType& instTuple)
 
     // 4. nop out the remaining bytes
     while (generator.m_writer.position() < end)
-        OpNop::emit<OpcodeSize::Narrow>(&generator);
+        OpNop::emit<OpcodeSize::Wide32>(&generator);
 }
 
 void ForInContext::finalize(BytecodeGenerator& generator, UnlinkedCodeBlockGenerator* codeBlock, unsigned bodyBytecodeEndOffset)
@@ -5540,7 +5540,7 @@ void ForInContext::finalize(BytecodeGenerator& generator, UnlinkedCodeBlockGener
 
         // 4. nop out the remaining bytes
         while (generator.m_writer.position() < end)
-            OpNop::emit<OpcodeSize::Narrow>(&generator);
+            OpNop::emit<OpcodeSize::Wide32>(&generator);
     }
 
     for (const auto& hasOwnPropertyTuple : m_hasOwnPropertyJumpInsts) {
@@ -5559,7 +5559,7 @@ void ForInContext::finalize(BytecodeGenerator& generator, UnlinkedCodeBlockGener
         OpJmp::emit(&generator, BoundLabel(static_cast<int>(newBranchTarget) - static_cast<int>(branchInstIndex)));
 
         while (generator.m_writer.position() < end)
-            OpNop::emit<OpcodeSize::Narrow>(&generator);
+            OpNop::emit<OpcodeSize::Wide32>(&generator);
     }
 
     generator.m_writer.seek(generator.m_writer.size());

--- a/projects/webkitgtk-2.44.3/Source/JavaScriptCore/generator/Opcode.rb
+++ b/projects/webkitgtk-2.44.3/Source/JavaScriptCore/generator/Opcode.rb
@@ -220,14 +220,14 @@ EOF
     static void emitWithSmallestSizeRequirement(BytecodeGenerator* gen#{typed_args})
     {
         #{@metadata.create_emitter_local}
-        if (static_cast<unsigned>(__size) <= static_cast<unsigned>(OpcodeSize::Narrow)) {
-            if (emit<OpcodeSize::Narrow, BytecodeGenerator, NoAssert, true>(gen#{untyped_args}#{metadata_arg}))
-                return;
-        }
-        if (static_cast<unsigned>(__size) <= static_cast<unsigned>(OpcodeSize::Wide16)) {
-            if (emit<OpcodeSize::Wide16, BytecodeGenerator, NoAssert, true>(gen#{untyped_args}#{metadata_arg}))
-                return;
-        }
+        //if (static_cast<unsigned>(__size) <= static_cast<unsigned>(OpcodeSize::Narrow)) {
+        //    if (emit<OpcodeSize::Narrow, BytecodeGenerator, NoAssert, true>(gen#{untyped_args}#{metadata_arg}))
+        //        return;
+        //}
+        //if (static_cast<unsigned>(__size) <= static_cast<unsigned>(OpcodeSize::Wide16)) {
+        //    if (emit<OpcodeSize::Wide16, BytecodeGenerator, NoAssert, true>(gen#{untyped_args}#{metadata_arg}))
+        //        return;
+        //}
         emit<OpcodeSize::Wide32, BytecodeGenerator, Assert, true>(gen#{untyped_args}#{metadata_arg});
     }
 

--- a/projects/webkitgtk-2.44.3/Source/JavaScriptCore/llint/LLIntThunks.cpp
+++ b/projects/webkitgtk-2.44.3/Source/JavaScriptCore/llint/LLIntThunks.cpp
@@ -757,55 +757,9 @@ MacroAssemblerCodeRef<JSEntryPtrTag> checkpointOSRExitFromInlinedCallTrampolineT
     return codeRef;
 }
 
-MacroAssemblerCodeRef<JSEntryPtrTag> returnLocationThunk(OpcodeID opcodeID, OpcodeSize size)
+MacroAssemblerCodeRef<JSEntryPtrTag> returnLocationThunk(OpcodeID , OpcodeSize )
 {
-#define LLINT_RETURN_LOCATION(name) \
-    case name##_return_location: { \
-        switch (size) { \
-        case OpcodeSize::Narrow: { \
-            static LazyNeverDestroyed<MacroAssemblerCodeRef<JSEntryPtrTag>> codeRef; \
-            static std::once_flag onceKey; \
-            std::call_once(onceKey, [&] { \
-                codeRef.construct(generateThunkWithJumpToLLIntReturnPoint<JSEntryPtrTag>(LLInt::getCodeFunctionPtr<OperationPtrTag>(name##_return_location),  #name "_return_location thunk")); \
-            }); \
-            return codeRef; \
-        } \
-        case OpcodeSize::Wide16: { \
-            static LazyNeverDestroyed<MacroAssemblerCodeRef<JSEntryPtrTag>> codeRef; \
-            static std::once_flag onceKey; \
-            std::call_once(onceKey, [&] { \
-                codeRef.construct(generateThunkWithJumpToLLIntReturnPoint<JSEntryPtrTag>(LLInt::getWide16CodeFunctionPtr<OperationPtrTag>(name##_return_location),  #name "_return_location16 thunk")); \
-            }); \
-            return codeRef; \
-        } \
-        case OpcodeSize::Wide32: { \
-            static LazyNeverDestroyed<MacroAssemblerCodeRef<JSEntryPtrTag>> codeRef; \
-            static std::once_flag onceKey; \
-            std::call_once(onceKey, [&] { \
-                codeRef.construct(generateThunkWithJumpToLLIntReturnPoint<JSEntryPtrTag>(LLInt::getWide32CodeFunctionPtr<OperationPtrTag>(name##_return_location), #name "_return_location32 thunk")); \
-            }); \
-            return codeRef; \
-        } \
-        } \
-        return { }; \
-    }
-
-    switch (opcodeID) {
-    LLINT_RETURN_LOCATION(op_call)
-    LLINT_RETURN_LOCATION(op_call_ignore_result)
-    LLINT_RETURN_LOCATION(op_iterator_open)
-    LLINT_RETURN_LOCATION(op_iterator_next)
-    LLINT_RETURN_LOCATION(op_construct)
-    LLINT_RETURN_LOCATION(op_call_varargs)
-    LLINT_RETURN_LOCATION(op_construct_varargs)
-    LLINT_RETURN_LOCATION(op_get_by_id)
-    LLINT_RETURN_LOCATION(op_get_by_val)
-    LLINT_RETURN_LOCATION(op_put_by_id)
-    LLINT_RETURN_LOCATION(op_put_by_val)
-    default:
-        RELEASE_ASSERT_NOT_REACHED();
-        return { };
-    }
+    UNREACHABLE_FOR_PLATFORM();
 }
 
 #endif

--- a/projects/webkitgtk-2.44.3/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
+++ b/projects/webkitgtk-2.44.3/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
@@ -497,17 +497,22 @@ macro op(l, fn)
 end
 
 macro llintOp(opcodeName, opcodeStruct, fn)
-    commonOp(llint_%opcodeName%, traceExecution, macro(size)
-        macro getImpl(fieldName, dst)
-            get(size, opcodeStruct, fieldName, dst)
-        end
 
-        macro dispatchImpl()
-            dispatchOp(size, opcodeName)
-        end
+_llint_%opcodeName%:
+    # Under fil-c, we don't emit 8-bit normal ops, just a few helpers like op_catch/op_wide32/etc
+    break
 
-        fn(size, getImpl, dispatchImpl)
-    end)
+_llint_%opcodeName%_wide32:
+    macro getImpl(fieldName, dst)
+        get(wide32, opcodeStruct, fieldName, dst)
+    end
+
+    macro dispatchImpl()
+        dispatchOp(wide32, opcodeName)
+    end
+
+    fn(wide32, getImpl, dispatchImpl)
+
 end
 
 macro llintOpWithReturn(opcodeName, opcodeStruct, fn)
@@ -2001,7 +2006,6 @@ end
 
 noWide(llint_op_wide16)
 noWide(llint_op_wide32)
-noWide(llint_op_enter)
 
 op(llint_program_prologue, macro ()
     prologue(_llint_entry_osr, _llint_trace_prologue)

--- a/projects/webkitgtk-2.44.3/Source/JavaScriptCore/llint/LowLevelInterpreter64.asm
+++ b/projects/webkitgtk-2.44.3/Source/JavaScriptCore/llint/LowLevelInterpreter64.asm
@@ -831,6 +831,9 @@ end
 # Instruction implementations
 
 _llint_op_enter:
+    crash()
+
+_llint_op_enter_wide32:
     traceExecution()
     checkStackPointerAlignment(t2, 0xdead00e1)
     loadp CodeBlock[cfr], t2                // t2<CodeBlock> = cfr.CodeBlock
@@ -850,9 +853,8 @@ _llint_op_enter:
     callSlowPath(_slow_path_enter)
 
     checkTraps(macro()
-        dispatchOp(narrow, op_enter)
+        dispatchOp(wide32, op_enter)
     end)
-
 
 llintOpWithProfile(op_get_argument, OpGetArgument, macro (size, get, dispatch, return)
     get(m_index, t2)


### PR DESCRIPTION
And change the code the following way:
- Always emit Wide32 bytecodes.
- Make narrow bytecodes crash() if control reaches them.

In the future, this can be improved in two ways:
- Make it faster by killing off how dispatching will now go through the wide_32 opcode.
- Make the code cleaner by killing any notion of opcode sizes.