### PR TITLE
Make property enumerator caching in StructureRareData preserve the

### DIFF
--- a/projects/webkitgtk-2.44.3/Source/JavaScriptCore/runtime/JSPropertyNameEnumerator.h
+++ b/projects/webkitgtk-2.44.3/Source/JavaScriptCore/runtime/JSPropertyNameEnumerator.h
@@ -122,9 +122,9 @@ inline JSPropertyNameEnumerator* propertyNameEnumerator(JSGlobalObject* globalOb
 
     Structure* structure = base->structure();
     if (!indexedLength) {
-        uintptr_t enumeratorAndFlag = structure->cachedPropertyNameEnumeratorAndFlag();
+        void* enumeratorAndFlag = structure->cachedPropertyNameEnumeratorAndFlag();
         if (enumeratorAndFlag) {
-            if (!(enumeratorAndFlag & StructureRareData::cachedPropertyNameEnumeratorIsValidatedViaTraversingFlag))
+            if (!(bitwise_cast<uintptr_t>(enumeratorAndFlag) & StructureRareData::cachedPropertyNameEnumeratorIsValidatedViaTraversingFlag))
                 return bitwise_cast<JSPropertyNameEnumerator*>(enumeratorAndFlag);
             structure->prototypeChain(vm, globalObject, base); // Refresh cached structure chain.
             if (auto* enumerator = structure->cachedPropertyNameEnumerator())

--- a/projects/webkitgtk-2.44.3/Source/JavaScriptCore/runtime/Structure.cpp
+++ b/projects/webkitgtk-2.44.3/Source/JavaScriptCore/runtime/Structure.cpp
@@ -1500,10 +1500,10 @@ JSPropertyNameEnumerator* Structure::cachedPropertyNameEnumerator() const
     return rareData()->cachedPropertyNameEnumerator();
 }
 
-uintptr_t Structure::cachedPropertyNameEnumeratorAndFlag() const
+void* Structure::cachedPropertyNameEnumeratorAndFlag() const
 {
     if (!hasRareData())
-        return 0;
+        return nullptr;
     return rareData()->cachedPropertyNameEnumeratorAndFlag();
 }
 

--- a/projects/webkitgtk-2.44.3/Source/JavaScriptCore/runtime/Structure.h
+++ b/projects/webkitgtk-2.44.3/Source/JavaScriptCore/runtime/Structure.h
@@ -682,7 +682,7 @@ public:
     
     void setCachedPropertyNameEnumerator(VM&, JSPropertyNameEnumerator*, StructureChain*);
     JSPropertyNameEnumerator* cachedPropertyNameEnumerator() const;
-    uintptr_t cachedPropertyNameEnumeratorAndFlag() const;
+    void* cachedPropertyNameEnumeratorAndFlag() const;
     bool canCachePropertyNameEnumerator(VM&) const;
     bool canAccessPropertiesQuicklyForEnumeration() const;
 

--- a/projects/webkitgtk-2.44.3/Source/JavaScriptCore/runtime/StructureRareData.h
+++ b/projects/webkitgtk-2.44.3/Source/JavaScriptCore/runtime/StructureRareData.h
@@ -92,7 +92,7 @@ public:
     void cacheSpecialProperty(JSGlobalObject*, VM&, Structure* baseStructure, JSValue, CachedSpecialPropertyKey, const PropertySlot&);
 
     JSPropertyNameEnumerator* cachedPropertyNameEnumerator() const;
-    uintptr_t cachedPropertyNameEnumeratorAndFlag() const;
+    void* cachedPropertyNameEnumeratorAndFlag() const;
     void setCachedPropertyNameEnumerator(VM&, Structure*, JSPropertyNameEnumerator*, StructureChain*);
     void clearCachedPropertyNameEnumerator();
 
@@ -165,7 +165,7 @@ private:
 
     // FIXME: We should have some story for clearing these property names caches in GC.
     // https://bugs.webkit.org/show_bug.cgi?id=192659
-    uintptr_t m_cachedPropertyNameEnumeratorAndFlag { 0 };
+    void* m_cachedPropertyNameEnumeratorAndFlag { 0 };
     FixedVector<StructureChainInvalidationWatchpoint> m_cachedPropertyNameEnumeratorWatchpoints;
     WriteBarrier<JSImmutableButterfly> m_cachedPropertyNames[numberOfCachedPropertyNames] { };
 

--- a/projects/webkitgtk-2.44.3/Source/JavaScriptCore/runtime/StructureRareDataInlines.h
+++ b/projects/webkitgtk-2.44.3/Source/JavaScriptCore/runtime/StructureRareDataInlines.h
@@ -97,10 +97,11 @@ inline JSValue StructureRareData::cachedSpecialProperty(CachedSpecialPropertyKey
 
 inline JSPropertyNameEnumerator* StructureRareData::cachedPropertyNameEnumerator() const
 {
-    return bitwise_cast<JSPropertyNameEnumerator*>(m_cachedPropertyNameEnumeratorAndFlag & cachedPropertyNameEnumeratorMask);
+    return bitwise_cast<JSPropertyNameEnumerator*>(zmkptr(m_cachedPropertyNameEnumeratorAndFlag,
+                bitwise_cast<uintptr_t>(m_cachedPropertyNameEnumeratorAndFlag) & cachedPropertyNameEnumeratorMask));
 }
 
-inline uintptr_t StructureRareData::cachedPropertyNameEnumeratorAndFlag() const
+inline void* StructureRareData::cachedPropertyNameEnumeratorAndFlag() const
 {
     return m_cachedPropertyNameEnumeratorAndFlag;
 }
@@ -109,7 +110,8 @@ inline void StructureRareData::setCachedPropertyNameEnumerator(VM& vm, Structure
 {
     m_cachedPropertyNameEnumeratorWatchpoints = FixedVector<StructureChainInvalidationWatchpoint>();
     bool validatedViaWatchpoint = tryCachePropertyNameEnumeratorViaWatchpoint(vm, baseStructure, chain);
-    m_cachedPropertyNameEnumeratorAndFlag = ((validatedViaWatchpoint ? 0 : cachedPropertyNameEnumeratorIsValidatedViaTraversingFlag) | bitwise_cast<uintptr_t>(enumerator));
+    m_cachedPropertyNameEnumeratorAndFlag = zmkptr(enumerator, 
+        bitwise_cast<uintptr_t>(enumerator) | (validatedViaWatchpoint ? 0 : cachedPropertyNameEnumeratorIsValidatedViaTraversingFlag));
     vm.writeBarrier(this, enumerator);
 }
 
@@ -210,7 +212,7 @@ inline bool StructureRareData::tryCachePropertyNameEnumeratorViaWatchpoint(VM&, 
 
 inline void StructureRareData::clearCachedPropertyNameEnumerator()
 {
-    m_cachedPropertyNameEnumeratorAndFlag = 0;
+    m_cachedPropertyNameEnumeratorAndFlag = nullptr;
     m_cachedPropertyNameEnumeratorWatchpoints = FixedVector<StructureChainInvalidationWatchpoint>();
 }
 


### PR DESCRIPTION
capability.

After this patch, we now run all three benchmarks.