### PR TITLE
Fix union codegen performance regression via zhas_union intrinsic

### DIFF
--- a/clang/lib/CodeGen/CGDecl.cpp
+++ b/clang/lib/CodeGen/CGDecl.cpp
@@ -1583,6 +1583,8 @@ CodeGenFunction::EmitAutoVarAlloca(const VarDecl &D) {
       // builds.
       address = CreateTempAlloca(allocaTy, allocaAlignment, D.getName(),
                                  /*ArraySize=*/nullptr, &AllocaAddr);
+      if (auto *AI = dyn_cast<llvm::AllocaInst>(AllocaAddr.getPointer()))
+        EmitZhasUnionIfNeeded(Ty, AI);
 
       // Don't emit lifetime markers for MSVC catch parameters. The lifetime of
       // the catch parameter starts in the catchpad instruction, and we can't

--- a/clang/lib/CodeGen/CGExpr.cpp
+++ b/clang/lib/CodeGen/CGExpr.cpp
@@ -155,7 +155,10 @@ RawAddress CodeGenFunction::CreateDefaultAlignTempAlloca(llvm::Type *Ty,
 
 RawAddress CodeGenFunction::CreateIRTemp(QualType Ty, const Twine &Name) {
   CharUnits Align = getContext().getTypeAlignInChars(Ty);
-  return CreateTempAlloca(ConvertType(Ty), Align, Name);
+  auto Result = CreateTempAlloca(ConvertType(Ty), Align, Name);
+  if (auto *AI = dyn_cast<llvm::AllocaInst>(Result.getPointer()))
+    EmitZhasUnionIfNeeded(Ty, AI);
+  return Result;
 }
 
 RawAddress CodeGenFunction::CreateMemTemp(QualType Ty, const Twine &Name,
@@ -167,8 +170,13 @@ RawAddress CodeGenFunction::CreateMemTemp(QualType Ty, const Twine &Name,
 RawAddress CodeGenFunction::CreateMemTemp(QualType Ty, CharUnits Align,
                                           const Twine &Name,
                                           RawAddress *Alloca) {
+  RawAddress AllocaAddr = RawAddress::invalid();
   RawAddress Result = CreateTempAlloca(ConvertTypeForMem(Ty), Align, Name,
-                                       /*ArraySize=*/nullptr, Alloca);
+                                       /*ArraySize=*/nullptr, &AllocaAddr);
+  if (auto *AI = dyn_cast<llvm::AllocaInst>(AllocaAddr.getPointer()))
+    EmitZhasUnionIfNeeded(Ty, AI);
+  if (Alloca)
+    *Alloca = AllocaAddr;
 
   if (Ty->isConstantMatrixType()) {
     auto *ArrayTy = cast<llvm::ArrayType>(Result.getElementType());
@@ -184,13 +192,28 @@ RawAddress CodeGenFunction::CreateMemTemp(QualType Ty, CharUnits Align,
 RawAddress CodeGenFunction::CreateMemTempWithoutCast(QualType Ty,
                                                      CharUnits Align,
                                                      const Twine &Name) {
-  return CreateTempAllocaWithoutCast(ConvertTypeForMem(Ty), Align, Name);
+  auto Result = CreateTempAllocaWithoutCast(ConvertTypeForMem(Ty), Align, Name);
+  if (auto *AI = dyn_cast<llvm::AllocaInst>(Result.getPointer()))
+    EmitZhasUnionIfNeeded(Ty, AI);
+  return Result;
 }
 
 RawAddress CodeGenFunction::CreateMemTempWithoutCast(QualType Ty,
                                                      const Twine &Name) {
   return CreateMemTempWithoutCast(Ty, getContext().getTypeAlignInChars(Ty),
                                   Name);
+}
+
+void CodeGenFunction::EmitZhasUnionIfNeeded(QualType Ty,
+                                             llvm::AllocaInst *AI) {
+  if (!Ty.hasUnion())
+    return;
+  llvm::IRBuilderBase::InsertPointGuard IPG(Builder);
+  Builder.SetInsertPoint(AI->getNextNode());
+  Builder.CreateCall(
+    CGM.CreateRuntimeFunction(
+      llvm::FunctionType::get(VoidTy, { Int8PtrTy }, false), "zhas_union"),
+    { AI });
 }
 
 /// EvaluateExprAsBool - Perform the usual unary conversions on the specified

--- a/clang/lib/CodeGen/CGExprAgg.cpp
+++ b/clang/lib/CodeGen/CGExprAgg.cpp
@@ -2251,12 +2251,7 @@ void CodeGenFunction::EmitAggregateCopy(LValue Dest, LValue Src, QualType Ty,
     }
   }
 
-  size_t SizeInt = SIZE_MAX;
-  if (llvm::ConstantInt* SizeValInt = dyn_cast<llvm::ConstantInt>(SizeVal)) {
-    if (SizeValInt->getBitWidth() <= 64)
-      SizeInt = SizeValInt->getZExtValue();
-  }
-  if (SizeInt >= 8) {
+  if (Ty.hasUnion()) {
     Builder.CreateCall(
       CGM.CreateRuntimeFunction(
         llvm::FunctionType::get(VoidTy, { Int8PtrTy, Int8PtrTy, SizeTy }, false), "zmemmove_union"),

--- a/clang/lib/CodeGen/CodeGenFunction.h
+++ b/clang/lib/CodeGen/CodeGenFunction.h
@@ -2885,6 +2885,11 @@ public:
   RawAddress CreateMemTempWithoutCast(QualType T, CharUnits Align,
                                       const Twine &Name = "tmp");
 
+  /// EmitZhasUnionIfNeeded - If the type contains a union, emit a call to
+  /// the zhas_union pseudo-intrinsic on the alloca. This prevents SROA from
+  /// decomposing the alloca while FilPizlonator treats it as a no-op.
+  void EmitZhasUnionIfNeeded(QualType Ty, llvm::AllocaInst *AI);
+
   /// CreateAggTemp - Create a temporary memory object for the given
   /// aggregate type.
   AggValueSlot CreateAggTemp(QualType T, const Twine &Name = "tmp",

--- a/clang/lib/Serialization/ASTReaderDecl.cpp
+++ b/clang/lib/Serialization/ASTReaderDecl.cpp
@@ -835,6 +835,7 @@ RedeclarableResult ASTDeclReader::VisitRecordDeclImpl(RecordDecl *RD) {
       RecordDeclBits.getNextBit());
   RD->setHasNonTrivialToPrimitiveDestructCUnion(RecordDeclBits.getNextBit());
   RD->setHasNonTrivialToPrimitiveCopyCUnion(RecordDeclBits.getNextBit());
+  RD->setHasUnion(RecordDeclBits.getNextBit());
   RD->setHasUninitializedExplicitInitFields(RecordDeclBits.getNextBit());
   RD->setParamDestroyedInCallee(RecordDeclBits.getNextBit());
   RD->setArgPassingRestrictions(

--- a/clang/lib/Serialization/ASTWriterDecl.cpp
+++ b/clang/lib/Serialization/ASTWriterDecl.cpp
@@ -626,6 +626,7 @@ void ASTDeclWriter::VisitRecordDecl(RecordDecl *D) {
   RecordDeclBits.addBit(D->hasNonTrivialToPrimitiveDefaultInitializeCUnion());
   RecordDeclBits.addBit(D->hasNonTrivialToPrimitiveDestructCUnion());
   RecordDeclBits.addBit(D->hasNonTrivialToPrimitiveCopyCUnion());
+  RecordDeclBits.addBit(D->hasUnion());
   RecordDeclBits.addBit(D->hasUninitializedExplicitInitFields());
   RecordDeclBits.addBit(D->isParamDestroyedInCallee());
   RecordDeclBits.addBits(llvm::to_underlying(D->getArgPassingRestrictions()), 2);

--- a/llvm/lib/Transforms/Instrumentation/FilPizlonator.cpp
+++ b/llvm/lib/Transforms/Instrumentation/FilPizlonator.cpp
@@ -4131,6 +4131,7 @@ class Pizlonator {
 
   bool functionWillReturn(Function* F) {
     return F->willReturn() ||
+      F->getName() == "zhas_union" ||
       F->getName() == "zmemmove_union" ||
       F->getName() == "zmemmove_builtin" ||
       F->getName() == "zgc_alloc" ||
@@ -7377,6 +7378,15 @@ class Pizlonator {
           return true;
         }
 
+        if (F->getName() == "zhas_union" &&
+            FT->getNumParams() == 1 &&
+            !FT->isVarArg() &&
+            FT->getReturnType() == VoidTy &&
+            FT->getParamType(0) == RawPtrTy) {
+          Erasify();
+          return true;
+        }
+
         if ((F->getName() == "zmemmove_union" || F->getName() == "zmemmove_builtin")
             && isMemmoveFT(FT)) {
           lowerMemmoveCall(CI);
@@ -9299,6 +9309,13 @@ class Pizlonator {
           mergeKind(cast<CallBase>(I)->getArgOperand(0), PointerKind::LocalExplicit);
           mergeKind(cast<CallBase>(I)->getArgOperand(1), PointerKind::LocalExplicit);
           continue;
+        }
+
+        if (CallBase* CI = dyn_cast<CallBase>(I)) {
+          if (Function* F = dyn_cast<Function>(CI->getCalledOperand())) {
+            if (F->getName() == "zhas_union")
+              continue;
+          }
         }
 
         if (LoadInst* LI = dyn_cast<LoadInst>(I)) {


### PR DESCRIPTION
[Generated with LLM assistance]

## Summary

- Fixes the 2% benchmark regression from commit 83cfe59bc716
- Introduces `zhas_union` pseudo-intrinsic to block SROA on union-containing allocas
- Reverts `EmitAggregateCopy` to only use `zmemmove_union` for types with `Ty.hasUnion()`
- Fixes PCH/Modules serialization bug where `HasUnion` bit was not being serialized

## Approach

Instead of blocking SROA at the copy site (zmemmove_union for all copies >= 8 bytes), block SROA at the alloca site:
- Emit `zhas_union(alloca)` for any alloca whose type contains a union
- SROA sees the opaque call and skips the alloca
- FilPizlonator treats `zhas_union` as a complete no-op (erases it)

This restores SROA optimization for the common non-union case while maintaining correctness for union types.

## Test plan

- [x] `optional1` and `optional2` tests pass (union correctness)
- [x] Full test suite passes (one unrelated pre-existing failure in `miscsyscall`)
- [x] Verified IR: union types get `zhas_union` + `zmemmove_union`, non-union types use regular `memcpy`