### PR TITLE
Drop debug markers in removeIrrelevantIntrinsics()

### DIFF
--- a/llvm/lib/Transforms/Instrumentation/FilPizlonator.cpp
+++ b/llvm/lib/Transforms/Instrumentation/FilPizlonator.cpp
@@ -13159,6 +13159,8 @@ class Pizlonator {
       for (BasicBlock& BB : F) {
         std::vector<Instruction*> ToErase;
         for (Instruction& I : BB) {
+          if (I.DebugMarker)
+            I.DebugMarker->eraseFromParent();
           CallBase* CI = dyn_cast<CallBase>(&I);
           if (!CI)
             continue;


### PR DESCRIPTION
We need to delete debug markers for the same reason that we delete llvm.dbg.declare intrinsics, namely that we RAUW the pointer argument with a non-pointer. We were getting away with not doing this on x86_64, but on arm64 I was seeing assertion failures without this.