### PR TITLE
Explicitly link musl against yolort

### DIFF
--- a/build_usermusl.sh
+++ b/build_usermusl.sh
@@ -30,7 +30,7 @@ set -x
 
 cd projects/usermusl
 
-CC="$CCPREFIX$PWD/../../build/bin/clang" ./configure --prefix=$PWD/../../pizfix
+CC="$CCPREFIX$PWD/../../build/bin/clang" ./configure --prefix=$PWD/../../pizfix LIBCC=-lyolort
 $MAKE clean
 $MAKE -j $NCPU
 $MAKE install

--- a/build_yolomusl.sh
+++ b/build_yolomusl.sh
@@ -29,7 +29,7 @@ set -e
 set -x
 
 cd projects/yolomusl
-./configure --prefix=$PWD/../../pizfix/yolo --syslibdir=$PWD/../../pizfix/yolo/lib
+./configure --prefix=$PWD/../../pizfix/yolo --syslibdir=$PWD/../../pizfix/yolo/lib LIBCC=$PWD/../../pizfix/lib/libyolort.a
 $MAKE clean
 $MAKE -j $NCPU
 $MAKE install


### PR DESCRIPTION
Currently, usermusl will attempt to link against the system libgcc, which is not necessarily ABI compatible with yolomusl. This doesn't usually matter because libgcc mostly doesn't depend on libc, but the support runtime for -moutline-atomics (which clang enables by default) calls getauxval. Fix it by explicitly linking usermusl against yolort.

The same issue could affect yolomusl if it were built with clang, and in any case it's not a good idea to have known potential ABI bugs, so do the same for yolomusl.