### PR TITLE
Include CFLAGS in PASCFLAGS

### DIFF
--- a/libpas/common.mk
+++ b/libpas/common.mk
@@ -22,7 +22,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
 
-PASCFLAGS = -g -O3 -W -Werror -fno-strict-aliasing -MD
+PASCFLAGS = -g -O3 -W -Werror -fno-strict-aliasing -MD $(CFLAGS)
 PASASMFLAGS = 
 PASSRCS = \
 	src/libpas/bmalloc_heap.c \


### PR DESCRIPTION
It is sometimes useful to build the runtimes with custom flags. For example, on arm64, I pass -march=armv8.1-a to enable LSE atomics, as this is useful for debugging (because rr requires LSE atomics) and probably improves performance, but we don't generally need to depend on LSE atomics. musl respects CFLAGS but libpas doesn't. Therefore, add CFLAGS to PASCFLAGS so that developers can use CFLAGS to set build flags for all runtimes.