### PR TITLE
Make libpas buildable on arm64

### DIFF
--- a/libpas/Makefile
+++ b/libpas/Makefile
@@ -36,6 +36,14 @@ FILC_YOLO_LIB_DIR ?= $(FILC_LIB_DIR)
 FILC_DYNAMIC_LINKER ?= $(FILC_YOLO_LIB_DIR)/ld-yolo-x86_64.so
 FILC_RUNTIME_LIBS ?= -lyoloc -lyolom
 
+ARCH ?= $(shell uname -m)
+
+ifeq ($(ARCH),x86_64)
+ARCH_CFLAGS = -march=x86-64-v2
+else
+ARCH_CFLAGS =
+endif
+
 # We build the runtime with clang by default because doing so produces ~1.2% better performance on
 # PizBench9019. But building with g++ is supported.
 # HOST_CLANG ?= g++
@@ -48,11 +56,11 @@ HOST_CLANG_EXTRA_FLAGS = -isystem `./find_clang_include_dir.rb`
 FILC_CLANG ?= ../build/bin/clang
 FILC_DRIVER_FLAGS ?=
 
-PASCC = $(HOST_CLANG) -march=x86-64-v2 -fPIC -pthread -nostdinc \
+PASCC = $(HOST_CLANG) $(ARCH_CFLAGS) -fPIC -pthread -nostdinc \
 	-isystem $(FILC_YOLO_INCLUDE) -isystem $(FILC_OS_INCLUDE) \
 	-isystem $(FILC_STDFIL_INCLUDE) \
 	$(HOST_CLANG_EXTRA_FLAGS)
-PASASM = $(HOST_CLANG) -march=x86-64-v2 -fPIC
+PASASM = $(HOST_CLANG) $(ARCH_CFLAGS) -fPIC
 FILCC = $(FILC_CLANG) $(FILC_DRIVER_FLAGS)
 SHLD = $(HOST_CLANG) -Wl,-dynamic-linker,$(FILC_DYNAMIC_LINKER) \
 	-nostdlib -shared $(FILC_YOLO_LIB_DIR)/crti.o \
@@ -87,15 +95,15 @@ FILSRCS = $(wildcard ../filc/src/*.c)
 
 PASPIZLODYNAMICOBJSBASE = \
 	$(patsubst %.c,build/pas-pizlo-release-%.o,$(notdir $(PASSRCS))) \
-	$(patsubst %.s,build/pas-pizlo-release-%.o,$(notdir $(PASASMSRCS))) \
+	$(patsubst %.S,build/pas-pizlo-release-%.o,$(notdir $(PASASMSRCS))) \
 	build/pas-pizlo-release-filc_dynamic.o
 PASPIZLOSTATICOBJSBASE = \
 	$(patsubst %.c,build/pas-pizlo-release-%.o,$(notdir $(PASSRCS))) \
-	$(patsubst %.s,build/pas-pizlo-release-%.o,$(notdir $(PASASMSRCS))) \
+	$(patsubst %.S,build/pas-pizlo-release-%.o,$(notdir $(PASASMSRCS))) \
 	build/pas-pizlo-release-filc_static.o
 PASPIZLOTESTOBJSBASE = \
 	$(patsubst %.c,build/pas-pizlo-test-%.o,$(notdir $(PASSRCS))) \
-	$(patsubst %.s,build/pas-pizlo-release-%.o,$(notdir $(PASASMSRCS))) \
+	$(patsubst %.S,build/pas-pizlo-release-%.o,$(notdir $(PASASMSRCS))) \
 	build/pas-pizlo-test-filc_dynamic.o
 
 PASPIZLODYNAMICOBJS = \
@@ -162,7 +170,7 @@ build/pas-pizlo-test-%.o: src/libpas/%.c
 build/fil-pizlo-%.o: ../filc/src/%.c $(FILC_CLANG)
 	$(FILCC) $(FILCFLAGS) -c -o $@ $<
 
-build/pas-pizlo-release-%.o: src/libpas/%.s
+build/pas-pizlo-release-%.o: src/libpas/%.S
 	$(PASASM) $(PASASMFLAGS) -c -o $@ $<
 
 build/pas-pizlo-release-filc_runtime.o: src/libpas/filc_native.h

--- a/libpas/Makefile-check
+++ b/libpas/Makefile-check
@@ -23,8 +23,16 @@
 
 all: build/libpas.so build/test_pas
 
-PASCC = clang -march=x86-64-v2 -fPIC -pthread
-PASCXX = clang++ -march=x86-64-v2 -fPIC -pthread
+ARCH ?= $(shell uname -m)
+
+ifeq ($(ARCH),x86_64)
+ARCH_CFLAGS = -march=x86-64-v2
+else
+ARCH_CFLAGS =
+endif
+
+PASCC = clang $(ARCH_CFLAGS) -fPIC -pthread
+PASCXX = clang++ $(ARCH_CFLAGS) -fPIC -pthread
 
 PASCXXFLAGS = -g -O3 -W -Werror -std=c++17 -Wno-unused-parameter -Wno-sign-compare \
 	-Wno-missing-field-initializers -Wno-vla-cxx-extension -Wno-unknown-warning-option \

--- a/libpas/common.mk
+++ b/libpas/common.mk
@@ -201,5 +201,5 @@ PASSRCS = \
 	src/libpas/verse_heap_type.c \
 	src/libpas/verse_local_allocator.c
 
-PASASMSRCS = $(sort $(wildcard src/libpas/*.s))
+PASASMSRCS = $(sort $(wildcard src/libpas/*.S))
 

--- a/libpas/src/libpas/filc_stack_overflow_failure.S
+++ b/libpas/src/libpas/filc_stack_overflow_failure.S
@@ -35,20 +35,46 @@ filc_stack_overflow_failure:
         # spinlock. It has to be a spinlock because we're not on a valid stack right now, so we cannot
         # do anything complicated. Maybe we could do syscalls, but even that's sketchy. It can be a
         # spinlock because the whole point is we'll panic anyway, so perf doesn't matter.
+#if defined(__aarch64__)
+	mov x1, #1
+	adrp x16, lock
+	add x16, x16, #:lo12:lock
+.Lretry_lock:
+#ifdef __ARM_FEATURE_ATOMICS
+	mov x0, #0
+	casalb w0, w1, [x16]
+	cbnz x0, .Lretry_lock
+#else
+	clrex
+	ldaxrb w17, [x16]
+	cbnz w17, .Lretry_lock
+	stlxrb w17, w1, [x16]
+	cbnz w17, .Lretry_lock
+#endif
+#elif defined(__x86_64__)
 	movb $1, %cl
 .Lretry_lock:
 	xorl %eax, %eax
 	lock cmpxchgb %cl, lock(%rip)
 	jne .Lretry_lock
+#else
+#error "Unsupported architecture"
+#endif
         
         # Set up the failure_stack as our stack, just so we can call into the runtime to create a
-        # Fil-C panic. Note that the $8192 constant has to match the failure_stack's size, below.
-	leaq failure_stack(%rip), %rax
-        addq $8192, %rax
-        movq %rax, %rsp
-        
-        # Now create the Fil-C panic.
+        # Fil-C panic. Note that the 8192 constant has to match the failure_stack's size, below.
+        # Then create the Fil-C panic.
+#if defined(__aarch64__)
+	adrp x0, failure_stack+8192
+	add x0, x0, :lo12:failure_stack+8192
+	mov sp, x0
+	b filc_stack_overflow_failure_impl
+#elif defined(__x86_64__)
+	leaq failure_stack+8192(%rip), %rsp
 	call filc_stack_overflow_failure_impl@PLT
+#else
+#error "Unsupported architecture"
+#endif
 
         # This is the simple spinlock we use to protect the failure_stack.
 	.type lock,@object


### PR DESCRIPTION
- Pass -march=x86-64-v2 only when targeting x86_64.
- Rename filc_stack_overflow_failure.s to .S so that it will be preprocessed, and add an arm64 implementation.