### PR TITLE
Pass >16b variadic aggregates byval on aarch64

### DIFF
--- a/clang/lib/CodeGen/Targets/AArch64.cpp
+++ b/clang/lib/CodeGen/Targets/AArch64.cpp
@@ -465,7 +465,9 @@ ABIArgInfo AArch64ABIInfo::classifyArgumentType(QualType Ty, bool IsVariadicFn,
     return ABIArgInfo::getDirect(
         llvm::ArrayType::get(llvm::PointerType::get(getVMContext(), 0), 2));
 
-  return getNaturalAlignIndirect(Ty, /*ByVal=*/false);
+  // Variadic arguments must be byval, since EmitVAArg always reads them out of
+  // the varargs snapshot by value (for now).
+  return getNaturalAlignIndirect(Ty, /*ByVal=*/!IsNamedArg);
 }
 
 ABIArgInfo AArch64ABIInfo::classifyReturnType(QualType RetTy,


### PR DESCRIPTION
EmitVAArg reads variadic args out of the vararg snapshot as values, but on aarch64 `classifyArgumentType` passes aggregates over 16 bytes as a reference, so `va_arg` reads the aggregate's size from the 8-byte slot with the pointer, so at the very least `byvalvaarg5` fails (though, pleasingly, fails safe):

```
filc safety error: cannot read 20 bytes when upper - ptr = 8 (ptr = 0xfffeda404278,0xfffeda404270,0xfffeda404280,aux=0xfffeda408130,readonly).
    (bv5) filc/tests/byvalvaarg5/byvalvaarg5.c:16:11: fn
    (bv5) filc/tests/byvalvaarg5/byvalvaarg5.c:29:5: main
    (libc.so) src/env/__libc_start_main.c:79:7: __libc_start_main
    (libpizlo.so) <runtime>: start_program
[1789964] filc panic: thwarted a futile attempt to violate memory safety.
```

Mark variadic arguments byval, so snapshots get the actual aggregates.