### PR TITLE
Handle x86 stack checks with the large code model

### DIFF
--- a/llvm/lib/Transforms/Instrumentation/FilPizlonator.cpp
+++ b/llvm/lib/Transforms/Instrumentation/FilPizlonator.cpp
@@ -16407,12 +16407,24 @@ public:
                          /*hasSideEffects=*/true);
       break;
     case Triple::x86_64:
-      StackCheckAsm =
-          InlineAsm::get(FunctionType::get(VoidTy, {RawPtrTy}, false),
-                         "cmp %rsp, $0\n\t"
-                         "jae filc_stack_overflow_failure@PLT",
-                         "*m,~{memory},~{dirflag},~{fpsr},~{flags}",
-                         /*hasSideEffects=*/true);
+      if (M.getCodeModel() == CodeModel::Large) {
+        StackCheckAsm =
+            InlineAsm::get(FunctionType::get(VoidTy, {RawPtrTy}, false),
+                           "cmp %rsp, $0\n\t"
+                           "jb 1f\n\t"
+                           "movabs $$filc_stack_overflow_failure, %r11\n\t"
+                           "jmp *%r11\n\t"
+                           "1:",
+                           "*m,~{r11},~{memory},~{dirflag},~{fpsr},~{flags}",
+                           /*hasSideEffects=*/true);
+      } else {
+        StackCheckAsm =
+            InlineAsm::get(FunctionType::get(VoidTy, {RawPtrTy}, false),
+                           "cmp %rsp, $0\n\t"
+                           "jae filc_stack_overflow_failure@PLT",
+                           "*m,~{memory},~{dirflag},~{fpsr},~{flags}",
+                           /*hasSideEffects=*/true);
+      }
       break;
     default:
       report_fatal_error("Unknown arch");

--- a/llvm/lib/Transforms/Instrumentation/FilPizlonator.cpp
+++ b/llvm/lib/Transforms/Instrumentation/FilPizlonator.cpp
@@ -16408,15 +16408,31 @@ public:
       break;
     case Triple::x86_64:
       if (M.getCodeModel() == CodeModel::Large) {
-        StackCheckAsm =
-            InlineAsm::get(FunctionType::get(VoidTy, {RawPtrTy}, false),
-                           "cmp %rsp, $0\n\t"
-                           "jb 1f\n\t"
-                           "movabs $$filc_stack_overflow_failure, %r11\n\t"
-                           "jmp *%r11\n\t"
-                           "1:",
-                           "*m,~{r11},~{memory},~{dirflag},~{fpsr},~{flags}",
-                           /*hasSideEffects=*/true);
+        if (M.getPICLevel() == PICLevel::NotPIC) {
+          StackCheckAsm =
+              InlineAsm::get(FunctionType::get(VoidTy, {RawPtrTy}, false),
+                             "cmp %rsp, $0\n\t"
+                             "jb 1f\n\t"
+                             "movabs $$filc_stack_overflow_failure, %r11\n\t"
+                             "jmp *%r11\n\t"
+                             "1:",
+                             "*m,~{r11},~{memory},~{dirflag},~{fpsr},~{flags}",
+                             /*hasSideEffects=*/true);
+        } else {
+          StackCheckAsm =
+              InlineAsm::get(FunctionType::get(VoidTy, {RawPtrTy}, false),
+                             "cmp %rsp, $0\n\t"
+                             "jb 1f\n\t"
+                             "2:\n\t"
+                             "leaq 2b(%rip), %r10\n\t"
+                             "movabsq $$_GLOBAL_OFFSET_TABLE_-2b, %r11\n\t"
+                             "addq %r10, %r11\n\t"
+                             "movabsq $$filc_stack_overflow_failure@GOT, %r10\n\t"
+                             "jmp *(%r11,%r10)\n\t"
+                             "1:",
+                             "*m,~{r10},~{r11},~{memory},~{dirflag},~{fpsr},~{flags}",
+                             /*hasSideEffects=*/true);
+        }
       } else {
         StackCheckAsm =
             InlineAsm::get(FunctionType::get(VoidTy, {RawPtrTy}, false),
@@ -17361,4 +17377,3 @@ PreservedAnalyses FilPizlonatorPass::run(Module &M, ModuleAnalysisManager&) {
   P.run();
   return PreservedAnalyses::none();
 }
-


### PR DESCRIPTION
Large FilC-instrumented executables can place the stack-overflow helper outside the signed 32-bit displacement range used by the generated x86 `jae filc_stack_overflow_failure@PLT` branch. This makes the final link fail with a truncated `R_X86_64_PLT32` relocation even when the program is compiled with `-mcmodel=large`.

For the large code model, use an absolute indirect jump for non-PIC objects and a large-model GOT sequence for PIC objects. Keep the existing direct PLT branch for other code models.

This was reproduced while building ClickHouse with FilC 0.684. A compiler built from the patched 0.684 source completed successfully. A focused test verifies `R_X86_64_64` for the non-PIC helper reference, `R_X86_64_GOTPC64`/`R_X86_64_GOT64` for the PIC path, no `R_X86_64_PLT32`, and successful execution of the non-PIE large-model binary. The ClickHouse rebuild with this compiler is in progress, so this pull request remains a draft.
