### PR TITLE
Build both X86 and AArch64 backends so each Fil-C binary can crossbuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,52 @@ If you are using source, then you can also:
 
 - `cd optfil && sudo ./build.sh` - builds the `/opt/fil` distribution.
 
+## Cross Compiling
+
+The compiler in each binary distribution can target both X86_64 and ARM64 on
+Linux. Cross compilation works in either direction. To cross compile you need:
+
+- The same Fil-C release's binary distribution for the other architecture, for
+  its `pizfix` (runtime, libc, and libc++). Unpack it, run its `setup.sh` on the
+  host as usual, and link its `pizfix` next to this distribution's `pizfix` as
+  `pizfix-<arch>`:
+
+      ln -s /path/to/filc-0.685-linux-aarch64/pizfix pizfix-aarch64
+
+  For cross compilation, the compiler uses the target's `pizfix-<arch>`;
+  `--filc-resource-dir=` overrides it. `setup.sh` links `pizfix/os-include/asm`
+  to the host's kernel headers for that architecture
+  (`/usr/include/<arch>-linux-gnu/asm`, or `/usr/<arch>-linux-gnu/include/asm`
+  from `linux-libc-dev-arm64-cross` or `linux-libc-dev-amd64-cross` on
+  Debian/Ubuntu) and warns if there are none. For a cross header package, it
+  also uses that package's `linux` and `asm-generic` headers.
+  `--filc-os-include=` can point at a directory containing the target's
+  `asm`, `asm-generic`, and `linux` headers instead.
+
+- Binutils for the target, for example `binutils-aarch64-linux-gnu` on
+  Debian/Ubuntu, which clang finds automatically as `aarch64-linux-gnu-ld` and
+  `aarch64-linux-gnu-as`.
+
+Then, for example on X86_64:
+
+    build/bin/clang --target=aarch64-linux-gnu -o whatever whatever.c -O2 -g
+
+On ARM64, link the X86_64 runtime and compile with the ARM64 compiler:
+
+    ln -s /path/to/filc-0.685-linux-x86_64/pizfix pizfix-x86_64
+    build/bin/clang --target=x86_64-linux-gnu -o whatever whatever.c -O2 -g
+
+Use `build/bin/clang++` with the same target option for C++.
+
+The resulting executable records the target runtime's dynamic loader and
+library paths. To run it on the target machine, install the target distribution
+at those paths, or set `--filc-dynamic-linker=` and the linker runtime search
+path (`-Wl,-rpath,<dir>`) for the target machine's layout when linking.
+
+Assembly (`.s`) inputs are rewritten by the sarcasm assembler of the compiler's
+own `pizfix` (the one in the target's `pizfix` is a program built for the
+target) and then assembled with the target's `as`.
+
 ## Things That Work
 
 Lots of software packages work in Fil-C with zero or minimal changes, including

--- a/build_cxx.sh
+++ b/build_cxx.sh
@@ -82,6 +82,11 @@ cmake -S runtimes -B runtimes-build -G Ninja \
 (cd runtimes-build && ninja $NINJAFLAGS $NINJARUNTIMEFLAGS)
 
 ./install-cxx-$OS.sh
+# Mirror the per-target libc++ include directory (only __config_site, which is
+# architecture-independent) under the other triple so that
+# clang++ --target=$CROSSARCH-linux-gnu can find it (see package-build.sh).
+rm -rf build/include/$CROSSARCH-unknown-linux-gnu
+cp -R build/include/$ARCH-unknown-linux-gnu build/include/$CROSSARCH-unknown-linux-gnu
 ./fix_clang.sh
 
 

--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -195,6 +195,8 @@ def err_drv_sarcasm_missing : Error<
   "sarcasm assembler not found at %0 (install it with build_sarcasm.sh or pass -yolo-assembler)">;
 def err_drv_sarcasm_unsupported_option : Error<
   "'%0' is not supported by the sarcasm assembler (pass -yolo-assembler to use the built-in YOLO assembler)">;
+def err_drv_filc_cross_pizfix_missing : Error<
+  "cross compiling for %0 needs that architecture's Fil-C pizfix: install it as %1 or pass --filc-resource-dir=">;
 def err_drv_invalid_Xarch_argument_with_args : Error<
   "invalid Xarch argument: '%0', options requiring arguments are unsupported">;
 def err_drv_Xopenmp_target_missing_triple : Error<

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -1494,12 +1494,31 @@ Compilation *Driver::BuildCompilation(ArrayRef<const char *> ArgList) {
       Diag(diag::err_drv_unable_to_set_working_directory) << WD->getValue();
 
   // Check for Fil-C resource directory override
+  std::string MissingCrossPizfixArch;
   if (Arg *A = Args.getLastArg(options::OPT_filc_resource_dir)) {
     A->claim();
     PizfixRoot = A->getValue();
     HasPizfix = true;  // Trust the user-provided path
-  } else if (Arg *A = Args.getLastArg(options::OPT_filc_crt_path)) {
-    // If any filc flag is set, we're in filc mode
+  } else if (HasPizfix) {
+    // The pizfix next to the compiler is built for the host. When cross
+    // compiling, use the target architecture's pizfix installed next to it as
+    // pizfix-<arch> rather than silently linking against the wrong one.
+    llvm::Triple Target = computeTargetTriple(*this, TargetTriple, Args);
+    if (Target.getArch() !=
+        llvm::Triple(llvm::sys::getProcessTriple()).getArch()) {
+      StringRef ArchName = llvm::Triple::getArchTypeName(Target.getArch());
+      SmallString<128> P(Dir);
+      llvm::sys::path::append(P, "..", "..",
+                              "pizfix-" + ArchName.str());
+      llvm::sys::path::remove_dots(P, /*remove_dot_dot=*/true);
+      PizfixRoot = std::string(P);
+      if (!llvm::sys::fs::is_directory(P))
+        MissingCrossPizfixArch = ArchName.str();
+    }
+  }
+  // A CRT override changes the library directory, not the target's headers or
+  // dynamic loader. It must not bypass the cross-architecture pizfix selection.
+  if (Arg *A = Args.getLastArg(options::OPT_filc_crt_path)) {
     A->claim();
     HasPizfix = true;
   }
@@ -1785,6 +1804,14 @@ Compilation *Driver::BuildCompilation(ArrayRef<const char *> ArgList) {
 
   if (!HandleImmediateArgs(*C))
     return C;
+
+  // Queries such as --version and -dumpmachine do not need a target runtime.
+  if (!MissingCrossPizfixArch.empty()) {
+    Diag(diag::err_drv_filc_cross_pizfix_missing)
+        << MissingCrossPizfixArch << PizfixRoot;
+    C->setContainsError();
+    return C;
+  }
 
   // Construct the list of inputs.
   InputList Inputs;
@@ -6477,6 +6504,15 @@ void Driver::generatePrefixedToolNames(
     SmallVectorImpl<std::string> &Names) const {
   // FIXME: Needs a better variable than TargetTriple
   Names.emplace_back((TargetTriple + "-" + Tool).str());
+  // Also recognize architecture aliases such as arm64 and amd64 when looking
+  // for the aarch64-linux-gnu and x86_64-linux-gnu binutils.
+  llvm::Triple CanonicalTriple(TargetTriple);
+  if (CanonicalTriple.getArch() == llvm::Triple::aarch64 ||
+      CanonicalTriple.getArch() == llvm::Triple::x86_64) {
+    CanonicalTriple.setArch(CanonicalTriple.getArch());
+    if (CanonicalTriple.str() != TargetTriple)
+      Names.emplace_back((CanonicalTriple.str() + "-" + Tool).str());
+  }
   Names.emplace_back(Tool);
 }
 

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -57,6 +57,7 @@
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/Process.h"
+#include "llvm/Support/Program.h"
 #include "llvm/Support/YAMLParser.h"
 #include "llvm/TargetParser/AArch64TargetParser.h"
 #include "llvm/TargetParser/ARMTargetParserCommon.h"
@@ -9015,8 +9016,30 @@ void SarcasmAs::ConstructJob(Compilation &C, const JobAction &JA,
   // Resolve the sarcasm executable. In pizfix mode it lives next to the other
   // Fil-C tools; in /opt/fil mode it lives in the same directory as the
   // compiler; when installed pizlix style it is found on PATH.
+  //
+  // When cross compiling, the pizfix we compile against belongs to the target
+  // and its sarcasm is run by the target's minilute, so use the sarcasm of the
+  // compiler's own pizfix instead and have it run the target's assembler.
+  bool IsCross = getToolChain().getTriple().getArch() !=
+                 llvm::Triple(llvm::sys::getProcessTriple()).getArch();
   SmallString<128> SarcasmPath;
-  if (D.HasPizfix) {
+  if (IsCross) {
+    SarcasmPath = D.Dir;
+    llvm::sys::path::append(SarcasmPath, "..", "..", "pizfix");
+    llvm::sys::path::append(SarcasmPath, "bin", "sarcasm");
+    if (!llvm::sys::fs::can_execute(SarcasmPath)) {
+      SarcasmPath = D.Dir;
+      llvm::sys::path::append(SarcasmPath, "sarcasm");
+    }
+    if (!llvm::sys::fs::can_execute(SarcasmPath)) {
+      // -B and the target toolchain's program directories can contain target
+      // binaries. Only search the host PATH for this executable.
+      auto HostSarcasm = llvm::sys::findProgramByName("sarcasm");
+      SarcasmPath = HostSarcasm ? *HostSarcasm : "sarcasm";
+    }
+    CmdArgs.push_back("--as");
+    CmdArgs.push_back(Args.MakeArgString(getToolChain().GetProgramPath("as")));
+  } else if (D.HasPizfix) {
     SarcasmPath = D.PizfixRoot;
     llvm::sys::path::append(SarcasmPath, "bin");
     llvm::sys::path::append(SarcasmPath, "sarcasm");

--- a/clang/lib/Driver/ToolChains/Gnu.cpp
+++ b/clang/lib/Driver/ToolChains/Gnu.cpp
@@ -3516,7 +3516,11 @@ Generic_GCC::addLibCxxIncludePaths(const llvm::opt::ArgList &DriverArgs,
     {
       llvm::SmallString<128> P =
         llvm::StringRef(getDriver().Dir); // <install>/bin
-      llvm::sys::path::append(P, "..", "include", getTripleString());
+      llvm::Triple IncludeTriple = getTriple();
+      if (IncludeTriple.getArch() == llvm::Triple::aarch64 ||
+          IncludeTriple.getArch() == llvm::Triple::x86_64)
+        IncludeTriple.setArch(IncludeTriple.getArch());
+      llvm::sys::path::append(P, "..", "include", IncludeTriple.str());
       llvm::sys::path::append(P, "c++", "v1");
       addSystemInclude(DriverArgs, CC1Args, P);
     }

--- a/clang/lib/Driver/ToolChains/Linux.cpp
+++ b/clang/lib/Driver/ToolChains/Linux.cpp
@@ -470,7 +470,10 @@ std::string Linux::getDynamicLinker(const ArgList &Args) const {
       P = "/opt/fil";
     else
       P = "/";
-    llvm::sys::path::append(P, "lib", "ld-fil1-" + Triple.getArchName().str() + ".so");
+    StringRef ArchName = Triple.getArchName();
+    if (Arch == llvm::Triple::aarch64 || Arch == llvm::Triple::x86_64)
+      ArchName = llvm::Triple::getArchTypeName(Arch);
+    llvm::sys::path::append(P, "lib", "ld-fil1-" + ArchName.str() + ".so");
     return std::string(P);
   }
 

--- a/clang/test/Driver/Inputs/filc-cross.py
+++ b/clang/test/Driver/Inputs/filc-cross.py
@@ -1,0 +1,158 @@
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+# Optional arguments after the compiler are a runner, e.g.
+# /usr/bin/qemu-aarch64 -L /usr/aarch64-linux-gnu.
+compiler = Path(sys.argv[1]).absolute()
+runner = sys.argv[2:]
+native = subprocess.check_output(
+    [*runner, str(compiler), "--no-default-config", "-dumpmachine"], text=True
+).strip().split("-")[0]
+native = {"arm64": "aarch64", "amd64": "x86_64"}.get(native, native)
+
+
+@unittest.skipUnless(native in ("x86_64", "aarch64"), "requires a Fil-C host")
+class FilCCrossTest(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.clang = self.root / "build/bin/clang"
+        self.clang.parent.mkdir(parents=True)
+        self.clang.symlink_to(compiler)
+        self.cross = "aarch64" if native == "x86_64" else "x86_64"
+        self.host_pizfix = self.root / "pizfix"
+        self.cross_pizfix = self.root / ("pizfix-" + self.cross)
+        self.host_pizfix.mkdir()
+        self.cross_pizfix.mkdir()
+        self.path = self.root / "host-tools"
+        self.path.mkdir()
+        self.env = dict(os.environ, PATH=str(self.path))
+        self.env.pop("COMPILER_PATH", None)
+        self.env.pop("CCC_OVERRIDE_OPTIONS", None)
+        for arch in (native, self.cross):
+            for tool in ("as", "ld"):
+                self.executable(self.path / (arch + "-linux-gnu-" + tool))
+        self.host_sarcasm = self.host_pizfix / "bin/sarcasm"
+        self.executable(self.host_sarcasm)
+        self.executable(self.cross_pizfix / "bin/sarcasm")
+
+    def executable(self, path):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        # These tools must never actually run, even if this test regresses.
+        path.write_text("#!/bin/sh\nexit 99\n")
+        path.chmod(0o755)
+        return path
+
+    def invoke(self, *args, arch=None, query=False, success=True):
+        command = [
+            *runner, str(self.clang), "-no-canonical-prefixes",
+            "--no-default-config", "--target=" + (arch or self.cross) + "-linux-gnu",
+        ]
+        if not query:
+            command += ["-###", "-x", "c"]
+        command += list(args)
+        if not query:
+            command += ["/dev/null"]
+        result = subprocess.run(
+            command, env=self.env, text=True,
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+        )
+        self.assertEqual(result.returncode == 0, success, result.stdout)
+        # Native paths retain ../.., whereas selected cross paths are normalized.
+        return result.stdout.replace(str(self.clang.parent / "../.."), str(self.root))
+
+    def check_runtime(self, output, root, arch):
+        self.assertIn(str(root / "include"), output)
+        self.assertIn(str(root / "os-include"), output)
+        self.assertIn(str(root / ("lib/ld-fil1-" + arch + ".so")), output)
+
+    def test_native_and_cross_runtime(self):
+        for arch, root in ((native, self.host_pizfix), (self.cross, self.cross_pizfix)):
+            with self.subTest(arch=arch):
+                output = self.invoke(arch=arch)
+                self.check_runtime(output, root, arch)
+                self.assertIn(str(root / "lib/Scrt1.o"), output)
+
+    def test_crt_override_keeps_target_headers_and_loader(self):
+        crt = self.root / "custom-crt"
+        output = self.invoke("--filc-crt-path=" + str(crt))
+        self.check_runtime(output, self.cross_pizfix, self.cross)
+        self.assertIn(str(crt / "Scrt1.o"), output)
+        self.assertNotIn(str(self.host_pizfix / "include"), output)
+
+    def test_resource_override(self):
+        override = self.root / "custom-pizfix"
+        self.cross_pizfix.rename(override)
+        for extra in ((), ("--filc-crt-path=/custom-crt",)):
+            with self.subTest(extra=extra):
+                output = self.invoke("--filc-resource-dir=" + str(override), *extra)
+                self.check_runtime(output, override, self.cross)
+
+    def test_cxx_headers_in_both_directions(self):
+        for arch in (native, self.cross):
+            with self.subTest(arch=arch):
+                output = self.invoke("--driver-mode=g++", "-x", "c++", arch=arch)
+                self.assertIn("/include/" + arch + "-unknown-linux-gnu/c++/v1", output)
+                self.assertIn("/include/c++/v1", output)
+                self.assertIn('"-lc++"', output)
+
+    def test_missing_runtime_and_queries(self):
+        self.cross_pizfix.rename(self.root / "unused-pizfix")
+        for args in ((), ("--filc-crt-path=/custom-crt",)):
+            with self.subTest(args=args):
+                output = self.invoke(*args, success=False)
+                self.assertIn("cross compiling for " + self.cross, output)
+                self.assertIn(str(self.cross_pizfix), output)
+                self.assertNotIn('"-cc1"', output)
+        for query in ("-dumpmachine", "--version", "-print-resource-dir"):
+            with self.subTest(query=query):
+                self.invoke(query, query=True)
+
+    def test_aliases_use_canonical_runtime_headers_and_binutils(self):
+        alias = "arm64" if self.cross == "aarch64" else "amd64"
+        output = self.invoke("-x", "c++", arch=alias)
+        self.check_runtime(output, self.cross_pizfix, self.cross)
+        self.assertIn("/include/" + self.cross + "-unknown-linux-gnu/c++/v1", output)
+        self.assertIn(str(self.path / (self.cross + "-linux-gnu-ld")), output)
+        output = self.invoke("-###", "-c", "-x", "assembler", "/dev/null", arch=alias, query=True)
+        self.assertIn('"--as" "' + str(self.path / (self.cross + "-linux-gnu-as")), output)
+
+    def test_cross_assembly_uses_host_sarcasm_and_target_as(self):
+        output = self.invoke("-###", "-c", "-x", "assembler", "/dev/null", query=True)
+        self.assertIn(str(self.host_sarcasm), output)
+        self.assertNotIn(str(self.cross_pizfix / "bin/sarcasm"), output)
+        self.assertIn('"--as" "' + str(self.path / (self.cross + "-linux-gnu-as")), output)
+        self.assertIn('"--arm64"' if self.cross == "aarch64" else '"--x86_64"', output)
+
+    def test_cross_sarcasm_fallback_avoids_target_tool_directories(self):
+        self.host_sarcasm.unlink()
+        host_sarcasm = self.executable(self.path / "sarcasm")
+        target_tools = self.root / "target-tools"
+        target_sarcasm = self.executable(target_tools / "sarcasm")
+        target_as = self.executable(target_tools / "as")
+        output = self.invoke(
+            "-###", "-c", "-x", "assembler", "/dev/null", "-B" + str(target_tools),
+            query=True,
+        )
+        self.assertIn(str(host_sarcasm), output)
+        self.assertNotIn(str(target_sarcasm), output)
+        self.assertIn('"--as" "' + str(target_as), output)
+
+        # /opt/fil-style installs keep host sarcasm beside the compiler.
+        adjacent_sarcasm = self.executable(self.clang.parent / "sarcasm")
+        output = self.invoke(
+            "-###", "-c", "-x", "assembler", "/dev/null", "-B" + str(target_tools),
+            query=True,
+        )
+        self.assertIn(str(adjacent_sarcasm), output)
+        self.assertNotIn(str(target_sarcasm), output)
+
+
+if __name__ == "__main__":
+    unittest.main(argv=[sys.argv[0]])

--- a/clang/test/Driver/Inputs/filc-package-setup.py
+++ b/clang/test/Driver/Inputs/filc-package-setup.py
@@ -1,0 +1,74 @@
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+# Exercise only setup.sh generation and header symlinks, without packaging or
+# building anything. Replace /usr in the generated script with a temporary tree.
+source = Path(sys.argv[1]).read_text()
+start = source.index('echo "target_arch=$ARCH" >> setup.sh')
+end = source.index("\nEOF\n", start) + len("\nEOF\n")
+generator = source[start:end]
+
+
+class PackageSetupTest(unittest.TestCase):
+    def check_layout(self, target, host, layout):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            usr = root / "usr"
+            generic = usr / "include"
+            asm = None
+            if layout == "multiarch":
+                asm = generic / (target + "-linux-gnu/asm")
+            elif layout == "cross-package":
+                generic = usr / (target + "-linux-gnu/include")
+                asm = generic / "asm"
+            elif layout == "native":
+                asm = generic / "asm"
+            for name in ("linux", "asm-generic"):
+                (generic / name).mkdir(parents=True)
+            if asm:
+                asm.mkdir(parents=True)
+            # Foreign hosts may have flat host asm headers. Never select them.
+            if target != host:
+                (usr / "include/asm").mkdir(parents=True, exist_ok=True)
+            (root / "pizfix").mkdir()
+            tools = root / "tools"
+            tools.mkdir()
+            uname = tools / "uname"
+            uname.write_text("#!/bin/sh\necho " + host + "\n")
+            uname.chmod(0o755)
+            env = dict(os.environ, ARCH=target, PATH=str(tools) + os.pathsep + os.environ["PATH"])
+            subprocess.run(["sh", "-ec", generator], cwd=root, env=env, check=True)
+            setup = (root / "setup.sh").read_text().replace("/usr/", str(usr) + "/")
+            subprocess.run(["sh", "-n"], input=setup, text=True, check=True)
+            result = subprocess.run(
+                ["sh", "-ec", setup], cwd=root, env=env, text=True,
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True,
+            )
+            headers = root / "pizfix/os-include"
+            for name in ("linux", "asm-generic"):
+                self.assertEqual((headers / name).readlink(), generic / name)
+            if asm:
+                self.assertEqual((headers / "asm").readlink(), asm)
+                self.assertNotIn("warning:", result.stderr)
+            else:
+                self.assertFalse((headers / "asm").is_symlink())
+                self.assertIn("warning: no " + target + " kernel headers", result.stderr)
+
+    def test_header_layouts_in_both_directions(self):
+        for target in ("x86_64", "aarch64"):
+            other = "aarch64" if target == "x86_64" else "x86_64"
+            for host in (target, other):
+                for layout in ("multiarch", "cross-package", "missing"):
+                    with self.subTest(target=target, host=host, layout=layout):
+                        self.check_layout(target, host, layout)
+            with self.subTest(target=target, layout="native"):
+                self.check_layout(target, target, "native")
+
+
+if __name__ == "__main__":
+    unittest.main(argv=[sys.argv[0]])

--- a/clang/test/Driver/filc-cross.test
+++ b/clang/test/Driver/filc-cross.test
@@ -1,0 +1,6 @@
+# REQUIRES: system-linux
+# RUN: %python %S/Inputs/filc-cross.py %clang
+# RUN: %python %S/Inputs/filc-package-setup.py %S/../../../package-build.sh
+
+# Driver-only checks: no compiler, assembler, or linker jobs are executed.
+# Run this on both x86_64 and aarch64 hosts to cover both cross directions.

--- a/configure_llvm.sh
+++ b/configure_llvm.sh
@@ -34,10 +34,13 @@ set -x
 # build_cxx.sh, so that changing runtimes-only options (like whether the
 # runtimes are built against musl or glibc) never forces LLVM to be rebuilt.
 
+# Always build both the X86 and AArch64 backends so that the resulting compiler can
+# cross-compile for the other architecture (given that architecture's pizfix via
+# --filc-resource-dir), regardless of which architecture it was built on.
 export CMAKEOPTIONS="-S ../llvm -B . -G Ninja -DLLVM_ENABLE_PROJECTS=clang
     -DCMAKE_BUILD_TYPE=RelWithDebInfo -DLLVM_ENABLE_ASSERTIONS=ON
     -DLLVM_ENABLE_LLD=ON
-    -DLLVM_TARGETS_TO_BUILD=$LLVMARCH
+    -DLLVM_TARGETS_TO_BUILD=X86;AArch64
     -DLLVM_ENABLE_LIBXML2=OFF -DLLVM_ENABLE_LIBEDIT=OFF
     -DLLVM_ENABLE_LIBPFM=OFF -DLLVM_ENABLE_ZLIB=OFF -DLLVM_ENABLE_ZSTD=OFF
     -DLLVM_ENABLE_CURL=OFF -DLLVM_ENABLE_HTTPLIB=OFF

--- a/libpas/common.sh
+++ b/libpas/common.sh
@@ -36,11 +36,11 @@ esac
 case `uname -m` in
     amd64|x86_64)
         ARCH=x86_64
-        LLVMARCH=X86
+        CROSSARCH=aarch64
         ;;
     arm64|aarch64)
         ARCH=aarch64
-        LLVMARCH=AArch64
+        CROSSARCH=x86_64
         ;;
     *)
         echo "Unsupported arch"

--- a/package-build.sh
+++ b/package-build.sh
@@ -53,6 +53,10 @@ mkdir -p $build_name/build/include/
 cp -R build/include/c++ $build_name/build/include/
 mkdir -p $build_name/build/include/$ARCH-unknown-linux-gnu/
 cp -R build/include/$ARCH-unknown-linux-gnu/c++ $build_name/build/include/$ARCH-unknown-linux-gnu/
+# The compiler can also target $CROSSARCH. The per-target libc++ include directory only
+# holds __config_site, which is architecture-independent, so install it under the other
+# triple too so that clang++ --target=$CROSSARCH-linux-gnu can find it.
+cp -R $build_name/build/include/$ARCH-unknown-linux-gnu $build_name/build/include/$CROSSARCH-unknown-linux-gnu
 mkdir -p $build_name/build/lib/clang/20/
 cp -R build/lib/clang/20/include $build_name/build/lib/clang/20/
 
@@ -93,18 +97,30 @@ echo "fi" >> setup.sh
 rm pizfix/lib/ld-fil1-$ARCH.so
 (cd pizfix/lib/ && ln -s libyoloc.so ld-fil1-$ARCH.so)
 
-echo "cd pizfix" >> setup.sh
-echo "mkdir os-include" >> setup.sh
-echo "cd os-include" >> setup.sh
-echo "ln -s /usr/include/linux ." >> setup.sh
-echo "if test -d /usr/include/x86_64-linux-gnu/asm" >> setup.sh
-echo "then" >> setup.sh
-echo "    ln -s /usr/include/x86_64-linux-gnu/asm ." >> setup.sh
-echo "else" >> setup.sh
-echo "    ln -s /usr/include/asm ." >> setup.sh
-echo "fi" >> setup.sh
-echo "ln -s /usr/include/asm-generic ." >> setup.sh
-echo "cd ../.." >> setup.sh
+echo "target_arch=$ARCH" >> setup.sh
+cat >> setup.sh <<'EOF'
+cd pizfix
+mkdir os-include
+cd os-include
+kernel_include=/usr/include
+if test -d /usr/include/$target_arch-linux-gnu/asm
+then
+    ln -s /usr/include/$target_arch-linux-gnu/asm .
+elif test -d /usr/$target_arch-linux-gnu/include/asm
+then
+    # Use the matching generic headers from the cross header package too.
+    kernel_include=/usr/$target_arch-linux-gnu/include
+    ln -s $kernel_include/asm .
+elif test "`uname -m`" = "$target_arch" && test -d /usr/include/asm
+then
+    ln -s /usr/include/asm .
+else
+    echo "warning: no $target_arch kernel headers found; install them (for example linux-libc-dev-<arch>-cross on Debian/Ubuntu) and link their asm directory into pizfix/os-include, or compile with --filc-os-include=<dir>" >&2
+fi
+ln -s $kernel_include/linux .
+ln -s $kernel_include/asm-generic .
+cd ../..
+EOF
 
 echo 'set +x' >> setup.sh
 echo 'echo' >> setup.sh


### PR DESCRIPTION
Include both LLVM backends in each binary distribution so x86_64 and AArch64
hosts can compile for either architecture.

 Cross builds pick up the target runtime from pizfix-<arch>, or from --filc-
 resource-dir when specified. Assembly goes through the host’s sarcasm
 executable and the target’s assembler. The packages include libc++
 configuration headers for both targets, and setup selects the appropriate
 kernel headers.

 Also handle arm64/amd64 aliases consistently, keep CRT overrides from
 selecting host headers, and allow compiler queries without an installed target
 runtime. Add regression tests and document setup in both directions.

 Validated both compiler builds, C/C++/assembly cross-compilation, 53 native
 regression cases, and package relocation. AArch64 execution was tested under
 QEMU.
